### PR TITLE
Store scoped registry info in .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@folio:registry=https://repository.folio.org/repository/npm-folio/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ before_install:
   - sh -e /etc/init.d/xvfb start
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 0.27.5
   - export PATH=$HOME/.yarn/bin:$PATH
-  - yarn config set @folio:registry https://repository.folio.org/repository/npm-folio/
 install:
   - yarn
 cache:


### PR DESCRIPTION
Previously a fresh checkout of this repo required running `yarn config set @folio:registry https://repository.folio.org/repository/npm-folio/` before running `yarn install`.

Now that step of registering the `@folio` registry will be automatically taken care of.