### PR TITLE
Package Details Page

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -25,6 +25,13 @@ export default function () {
     return packages.where( { vendorId: request.params.vendorId } );
   });
 
+  this.get('/vendors/:vendorId/packages/:packageId', ({ packages }, request) => {
+    return packages.findBy({
+      vendorId: request.params.vendorId,
+      id: request.params.packageId
+    });
+  });
+
   // hot-reload passthrough
   this.pretender.get('/:rand.hot-update.json', this.pretender.passthrough);
 }

--- a/mirage/factories/package.js
+++ b/mirage/factories/package.js
@@ -3,7 +3,13 @@ import { Factory, faker } from 'mirage-server';
 export default Factory.extend({
   packageName: () => faker.commerce.productName(),
   titleCount: 1,
-  isSelected: 0,
+  isSelected: true,
   selectedCount: 1,
-  contentType: () => Math.floor(Math.random() * 8), // valid values: 0-7
+  contentType: () => faker.random.arrayElement([
+    'Online Reference',
+    'Aggregated Full Text',
+    'Abstract and Index',
+    'E-Book',
+    'E-Journal'
+  ])
 });

--- a/mirage/factories/vendor.js
+++ b/mirage/factories/vendor.js
@@ -15,11 +15,13 @@ export default Factory.extend({
 
       server.createList('package', vendor.packagesSelected, {
         vendor,
+        vendorName: vendor.vendorName,
         isSelected: 1
       });
 
       server.createList('package', (vendor.packagesTotal - vendor.packagesSelected), {
         vendor,
+        vendorName: vendor.vendorName,
         isSelected: 0
       });
     }

--- a/src/components/package-show/index.js
+++ b/src/components/package-show/index.js
@@ -1,0 +1,1 @@
+export { default } from './package-show';

--- a/src/components/package-show/package-show.js
+++ b/src/components/package-show/package-show.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function PackageShow({ vendorPackage }) {
+  return (
+    <div data-test-eholdings-package-details>
+      {vendorPackage.isLoaded ? (
+        <div>
+          <h3 data-test-eholdings-package-details-vendor>
+            Return to Vendor...
+          </h3>
+          <br/>
+          <h1 data-test-eholdings-package-details-name>
+            {vendorPackage.packageName}
+          </h1>
+          <p>
+            Content Type: <span data-test-eholdings-package-details-content-type>{vendorPackage.contentType}</span>
+          </p>
+          <p>
+            Selected: <input type='checkbox' checked={vendorPackage.isSelected} disabled data-test-eholdings-package-details-selected />
+          </p>
+          <p>
+            Total Titles: <span data-test-eholdings-package-details-titles-total>{vendorPackage.titleCount}</span>
+          </p>
+          <p>
+            Selected Titles: <span data-test-eholdings-package-details-titles-selected>{vendorPackage.selectedCount}</span>
+          </p>
+        </div>
+      ) : vendorPackage.isErrored ? (
+        vendorPackage.mapErrors((error, key) => (
+          <p key={key} data-test-eholdings-package-details-error>
+            {error.message}. {error.code}
+          </p>
+        ))
+      ) : (
+        <p>Loading...</p>
+      )}
+    </div>
+  );
+}
+
+PackageShow.propTypes = {
+  vendorPackage: PropTypes.object.isRequired
+};

--- a/src/components/package-show/package-show.js
+++ b/src/components/package-show/package-show.js
@@ -1,40 +1,47 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom'
+import Paneset from '@folio/stripes-components/lib/Paneset';
+import Pane from '@folio/stripes-components/lib/Pane';
+import KeyValue from '@folio/stripes-components/lib/KeyValue';
 
 export default function PackageShow({ vendorPackage }) {
   return (
     <div data-test-eholdings-package-details>
-      {vendorPackage.isLoaded ? (
-        <div>
-          <h3 data-test-eholdings-package-details-vendor>
-            Return to Vendor...
-          </h3>
-          <br/>
-          <h1 data-test-eholdings-package-details-name>
-            {vendorPackage.packageName}
-          </h1>
-          <p>
-            Content Type: <span data-test-eholdings-package-details-content-type>{vendorPackage.contentType}</span>
-          </p>
-          <p>
-            Selected: <input type='checkbox' checked={vendorPackage.isSelected} disabled data-test-eholdings-package-details-selected />
-          </p>
-          <p>
-            Total Titles: <span data-test-eholdings-package-details-titles-total>{vendorPackage.titleCount}</span>
-          </p>
-          <p>
-            Selected Titles: <span data-test-eholdings-package-details-titles-selected>{vendorPackage.selectedCount}</span>
-          </p>
-        </div>
-      ) : vendorPackage.isErrored ? (
-        vendorPackage.mapErrors((error, key) => (
-          <p key={key} data-test-eholdings-package-details-error>
-            {error.message}. {error.code}
-          </p>
-        ))
-      ) : (
-        <p>Loading...</p>
-      )}
+      <Paneset>
+        <Pane defaultWidth="100%">
+          {vendorPackage.isLoaded ? (
+            <div>
+              <h3 data-test-eholdings-package-details-vendor>
+                <Link to={`/eholdings/vendors/${vendorPackage.vendorId}`}>{vendorPackage.vendorName}</Link>
+              </h3>
+              <h1 data-test-eholdings-package-details-name>
+                {vendorPackage.packageName}
+              </h1>
+              <div data-test-eholdings-package-details-content-type>
+                <KeyValue label="Content Type" value={vendorPackage.contentType} />
+              </div>
+              <div data-test-eholdings-package-details-selected>
+                <KeyValue label="Selected" value={vendorPackage.isSelected ? 'SELECTED' : 'NOT SELECTED'} />
+              </div>
+              <div data-test-eholdings-package-details-titles-total>
+                <KeyValue label="Total Titles" value={vendorPackage.titleCount} />
+              </div>
+              <div data-test-eholdings-package-details-titles-selected>
+                <KeyValue label="Selected Titles" value={vendorPackage.selectedCount} />
+              </div>
+            </div>
+          ) : vendorPackage.isErrored ? (
+            vendorPackage.mapErrors((error, key) => (
+              <p key={key} data-test-eholdings-package-details-error>
+                {error.message}. {error.code}
+              </p>
+            ))
+          ) : (
+            <p>Loading...</p>
+          )}
+        </Pane>
+      </Paneset>
     </div>
   );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import Switch from 'react-router-dom/Switch';
 
 import App from './components/app';
 import VendorShow from './routes/vendor/vendor-show';
+import PackageShow from './routes/package/package-show';
 
 export default class EHoldings extends Component {
   static propTypes = {
@@ -19,6 +20,7 @@ export default class EHoldings extends Component {
     return(
       <Switch>
         <Route path={rootPath} exact component={App}/>
+        <Route path={`${rootPath}/vendors/:vendorId/packages/:packageId`} exact component={PackageShow}/>
         <Route path={`${rootPath}/vendors/:vendorId`} exact component={VendorShow}/>
       </Switch>
     );

--- a/src/routes/package/package-show.js
+++ b/src/routes/package/package-show.js
@@ -1,0 +1,86 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import fetch from 'isomorphic-fetch';
+
+import View from '../../components/package-show';
+
+export default class PackageShowRoute extends Component {
+  static propTypes = {
+    match: PropTypes.shape({
+      params: PropTypes.shape({
+        packageId: PropTypes.string.isRequired,
+        vendorId: PropTypes.string.isRequired
+      }).isRequired
+    }).isRequired
+  };
+
+  state = {
+    package: new PendingPackage({
+      id: this.props.match.params.packageId,
+      vendorId: this.props.match.params.vendorId
+    })
+  };
+
+  componentWillMount() {
+    let vendorPackage = this.state.package;
+
+    fetch(`/eholdings/vendors/${vendorPackage.vendorId}/packages/${vendorPackage.id}`)
+      .then(res => {
+        if (!res.ok) {
+          return res.text().then(body => { throw { status: res.status, body }; });
+        } else {
+          return res.json();
+        }
+      })
+      .then(payload => this.setState({ package: vendorPackage.resolve(payload) }))
+      .catch(error => this.setState({ package: vendorPackage.reject(error) }));
+  }
+
+  componentWillUnmount() {
+    this.setState = ()=> {};
+  }
+
+  render() {
+    return (<View vendorPackage={this.state.package}/>);
+  }
+}
+
+
+class Package {
+  constructor(prev = {}, props = {}) {
+    Object.assign(this, prev, props);
+  }
+
+  get isPending() { return false; }
+  get isLoaded() { return false; }
+  get isErrored() { return false; }
+}
+
+class PendingPackage extends Package {
+  get isPending()  { return true; }
+
+  resolve(data) {
+    return new LoadedPackage(this, data);
+  }
+
+  reject(error) {
+    return new ErroredPackage(this, { error });
+  }
+}
+
+class LoadedPackage extends Package {
+  get isLoaded() { return true; }
+}
+
+class ErroredPackage extends Package {
+  get isErrored() { return true; }
+
+  mapErrors(...args) {
+    try {
+      return JSON.parse(this.error.body).map(...args);
+    } catch (e) {
+      console.error(e);
+      return [];
+    }
+  }
+}

--- a/tests/harness.js
+++ b/tests/harness.js
@@ -28,6 +28,7 @@ export default class TestHarness extends Component {
     this.store = configureStore({ okapi });
     this.logger = configureLogger(config);
     this.mirage = startMirage();
+
     this.history = createMemoryHistory();
 
     discoverServices(okapi.url, this.store);

--- a/tests/package-show-test.js
+++ b/tests/package-show-test.js
@@ -1,0 +1,68 @@
+/* global describe, beforeEach */
+import { expect } from 'chai';
+import it from './it-will';
+
+import { describeApplication } from './helpers';
+import PackageShowPage from './pages/package-show';
+
+describeApplication('PackageShow', function() {
+  let vendor;
+  let vendorPackage;
+
+  beforeEach(function() {
+    vendorPackage = this.server.create('package', {
+      packageName: 'Cool Package',
+      contentType: 'e-book'
+    });
+    vendor = vendorPackage.createVendor({
+      vendorName: 'Cool Vendor'
+    });
+  });
+
+  describe("visiting the package details page", function() {
+    beforeEach(function() {
+      return this.visit(`/eholdings/vendors/${vendor.id}/packages/${vendorPackage.id}`, () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    it('displays the package name', function() {
+      expect(PackageShowPage.name).to.equal('Cool Package');
+    });
+
+    // skipped: this will be disabled until page is no longer read-only
+    it.skip('displays whether or not the package is selected', function() {
+      expect(PackageShowPage.isSelected).to.be.true;
+    });
+
+    it('displays the content type', function(){
+      expect(PackageShowPage.contentType).to.equal('e-book');
+    })
+
+    it('displays the total number of titles', function() {
+      expect(PackageShowPage.numTitles).to.equal(vendorPackage.titleCount);
+    });
+
+    it('displays the number of selected titles', function() {
+      expect(PackageShowPage.numTitlesSelected).to.equal(vendorPackage.selectedCount);
+    });
+  });
+
+  describe("encountering a server error", function() {
+    beforeEach(function() {
+      this.server.get('/vendors/:vendorId/packages/:packageId', [{
+        message: 'There was an error',
+        code: "1000",
+        subcode: 0
+      }], 500);
+
+      return this.visit(`/eholdings/vendors/${vendor.id}/packages/${vendorPackage.id}`, () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    it("dies with dignity", function() {
+      expect(PackageShowPage.hasErrors).to.be.true;
+    });
+  });
+});

--- a/tests/package-show-test.js
+++ b/tests/package-show-test.js
@@ -29,21 +29,20 @@ describeApplication('PackageShow', function() {
       expect(PackageShowPage.name).to.equal('Cool Package');
     });
 
-    it.skip('displays whether or not the package is selected', function() {
-      // skip: this will be disabled until page is no longer read-only
-      expect(PackageShowPage.isSelected).to.be.true;
+    it('displays whether or not the package is selected', function() {
+      expect(PackageShowPage.isSelected).to.equal(`Selected${vendorPackage.isSelected ? 'SELECTED' : 'NOT SELECTED'}`);
     });
 
     it('displays the content type', function(){
-      expect(PackageShowPage.contentType).to.equal('e-book');
+      expect(PackageShowPage.contentType).to.equal('Content Typee-book');
     })
 
     it('displays the total number of titles', function() {
-      expect(PackageShowPage.numTitles).to.equal(vendorPackage.titleCount);
+      expect(PackageShowPage.numTitles).to.equal(`Total Titles${vendorPackage.titleCount}`);
     });
 
     it('displays the number of selected titles', function() {
-      expect(PackageShowPage.numTitlesSelected).to.equal(vendorPackage.selectedCount);
+      expect(PackageShowPage.numTitlesSelected).to.equal(`Selected Titles${vendorPackage.selectedCount}`);
     });
   });
 

--- a/tests/package-show-test.js
+++ b/tests/package-show-test.js
@@ -6,8 +6,7 @@ import { describeApplication } from './helpers';
 import PackageShowPage from './pages/package-show';
 
 describeApplication('PackageShow', function() {
-  let vendor;
-  let vendorPackage;
+  let vendor, vendorPackage;
 
   beforeEach(function() {
     vendorPackage = this.server.create('package', {
@@ -30,8 +29,8 @@ describeApplication('PackageShow', function() {
       expect(PackageShowPage.name).to.equal('Cool Package');
     });
 
-    // skipped: this will be disabled until page is no longer read-only
     it.skip('displays whether or not the package is selected', function() {
+      // skip: this will be disabled until page is no longer read-only
       expect(PackageShowPage.isSelected).to.be.true;
     });
 

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -1,0 +1,30 @@
+import $ from 'jquery';
+import { triggerChange } from '../helpers';
+
+export default {
+  get $root() {
+    return $('[data-test-eholdings-package-details]');
+  },
+
+  get name() {
+    return $('[data-test-eholdings-package-details-name]').text();
+  },
+  get vendor() {
+    return $('[data-test-eholdings-package-details-vendor]').text();
+  },
+  get contentType() {
+    return $('[data-test-eholdings-package-details-content-type]').text();
+  },
+  get numTitles() {
+    return parseInt($('[data-test-eholdings-package-details-titles-total').text(), 10);
+  },
+  get numTitlesSelected() {
+    return parseInt($('[data-test-eholdings-package-details-titles-selected').text(), 10);
+  },
+  get isSelected() {
+    return $('[data-test-eholdings-package-details-selected]').value();
+  },
+  get hasErrors() {
+    return $('[data-test-eholdings-package-details-error]').length > 0;
+  }
+};

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -1,5 +1,4 @@
 import $ from 'jquery';
-import { triggerChange } from '../helpers';
 
 export default {
   get $root() {

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -15,13 +15,13 @@ export default {
     return $('[data-test-eholdings-package-details-content-type]').text();
   },
   get numTitles() {
-    return parseInt($('[data-test-eholdings-package-details-titles-total').text(), 10);
+    return $('[data-test-eholdings-package-details-titles-total').text();
   },
   get numTitlesSelected() {
-    return parseInt($('[data-test-eholdings-package-details-titles-selected').text(), 10);
+    return $('[data-test-eholdings-package-details-titles-selected').text();
   },
   get isSelected() {
-    return $('[data-test-eholdings-package-details-selected]').value();
+    return $('[data-test-eholdings-package-details-selected]').text();
   },
   get hasErrors() {
     return $('[data-test-eholdings-package-details-error]').length > 0;

--- a/tests/pages/vendor-details.js
+++ b/tests/pages/vendor-details.js
@@ -8,15 +8,12 @@ export default {
   get name() {
     return $('[data-test-eholdings-vendor-details-name]').text();
   },
-
   get hasErrors() {
     return $('[data-test-eholdings-vendor-details-error]').length > 0;
   },
-
   get numPackages() {
     return $('[data-test-eholdings-vendor-details-packages-total]').text();
   },
-
   get numPackagesSelected() {
     return $('[data-test-eholdings-vendor-details-packages-selected]').text();
   },


### PR DESCRIPTION
**Package Details (Show - Metadata)**
This is the 'show' page for a package, or more specifically a 'vendor package', since there is no API for package as-of-yet.

Currently this only displays a subset of read-only metadata for the package, as well as a link back to the parent vendor.  It makes use of `stripes-components` for some styling, but could probably use a better layout.

As for the list view that should accompany this page, I'm unsure if it should be titles or a list of other vendors providing the package.  I'm pretty sure the former, but if there is no pure "package details" page due to the RM API restriction, then I'm not sure where the latter would go.  We could put both here?

<img width="460" alt="screen shot 2017-08-09 at 9 53 46 pm" src="https://user-images.githubusercontent.com/14239162/29152610-ea643e32-7d4d-11e7-995e-eed04a799d7f.png">

