### PR TITLE
Put back vendor search

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -1,5 +1,8 @@
 import React, { Component } from 'react';
 import fetch from 'isomorphic-fetch';
+import { Link } from 'react-router-dom';
+import Paneset from '@folio/stripes-components/lib/Paneset';
+import Pane from '@folio/stripes-components/lib/Pane';
 
 export default class App extends Component {
   constructor() {
@@ -25,35 +28,42 @@ export default class App extends Component {
 
     return (
       <div data-test-eholdings>
-        <h1>Folio Resource Management</h1>
-        <form onSubmit={this.searchSubmit}>
-          <input
-            type="search"
-            name="search"
-            value={search}
-            placeholder="Search"
-            data-test-search-field
-            onChange={this.handleChange} />
-          <button data-test-search-submit type="submit" disabled={!search}>Search</button>
-        </form>
-        {!!errors && Array(errors).map((err, i) => (
-          <p key={i} data-test-search-error-message>
-            {err.message}. {err.code}
-          </p>
-        ))}
-        {(!hasSearchResults && searchQuery) ? (
-          <p data-test-search-no-results>
-            No results found for <strong>{`"${searchQuery}"`}</strong>.
-          </p>
-        ) : (
-          <ul data-test-search-results-list>
-            {hasSearchResults && searchResults.vendors.map((vendor) => (
-              <li data-test-search-results-item key={vendor.vendorId}>
-                {vendor.vendorName}
-              </li>
+        <Paneset>
+          <Pane
+            defaultWidth="100%"
+            header={
+              <form onSubmit={this.searchSubmit}>
+                <input
+                  type="search"
+                  name="search"
+                  value={search}
+                  placeholder="Search for vendors"
+                  data-test-search-field
+                  onChange={this.handleChange} />
+                <button data-test-search-submit type="submit" disabled={!search}>Search</button>
+              </form>
+            }>
+
+            {!!errors && Array(errors).map((err, i) => (
+              <p key={i} data-test-search-error-message>
+                {err.message}. {err.code}
+              </p>
             ))}
-          </ul>
-        )}
+            {(!hasSearchResults && searchQuery) ? (
+              <p data-test-search-no-results>
+                No results found for <strong>{`"${searchQuery}"`}</strong>.
+              </p>
+            ) : (
+              <ul data-test-search-results-list>
+                {hasSearchResults && searchResults.vendorList.map((vendor) => (
+                  <li data-test-search-results-item key={vendor.vendorId}>
+                    <Link to={`/eholdings/vendors/${vendor.vendorId}`}>{vendor.vendorName}</Link>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Pane>
+        </Paneset>
       </div>
     );
   }

--- a/tests/app-test.js
+++ b/tests/app-test.js
@@ -5,7 +5,7 @@ import it from './it-will';
 import { describeApplication } from './helpers';
 import AppPage from './pages/app';
 
-describeApplication.skip('eHoldings', function() {
+describeApplication('eHoldings', function() {
   beforeEach(function() {
     this.server.createList('vendor', 3, {
       vendorName: (i) => `Vendor${i + 1}`


### PR DESCRIPTION
Updates the previously-built vendor search to reflect accurate serialization.

While I was at it, I wrapped it in a `<Pane>` and linked to the vendor detail pages from the search results.

![localhost-3000-eholdings- iphone 5](https://user-images.githubusercontent.com/230597/29323881-da92b750-81a7-11e7-9c48-d9103832d885.png)
