### PR TITLE
Restore demo mirage data

### DIFF
--- a/demo/front.js
+++ b/demo/front.js
@@ -17,16 +17,15 @@ export default function Front() {
 
         <h3>Vendors</h3>
         <ul>
-          <li><Link to="/eholdings/vendors/6">Economist Intelligence Unit</Link></li>
-          <li><Link to="/eholdings/vendors/7">Edinburgh University Press</Link></li>
+          <li><Link to="/eholdings/vendors/1">Economist Intelligence Unit</Link></li>
+          <li><Link to="/eholdings/vendors/2">Edinburgh University Press</Link></li>
         </ul>
-        {/*
-            <h3>Packages</h3>
-              <ul>
-                <li><Link to="/eholdings/vendors/6/packages/26">EIU: Country Reports Archive (DFG Nationallizenz)</Link></li>
-                <li><Link to="/eholdings/vendors/7/packages/27">Digimap Ordnance Survey</Link></li>
-            </ul>
-        */}
+
+        <h3>Packages</h3>
+          <ul>
+            <li><Link to="/eholdings/vendors/6/packages/5">EIU: Country Reports Archive (DFG Nationallizenz)</Link></li>
+            <li><Link to="/eholdings/vendors/2/packages/6">Digimap Ordnance Survey</Link></li>
+        </ul>
 
       <p>
         <em>

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -1,80 +1,76 @@
 export default function(server) {
+  function createVendor(name, packages = []) {
+    let vendor = server.create('vendor', {
+      vendorName: name,
+      packagesTotal: 0
+    });
+    packages.forEach((pkg)=> {
+      server.create('package', 'withTitles', { ...pkg, vendor });
+    });
+  }
+
+  createVendor('Economist Intelligence Unit', [
+    {
+      packageName: 'Business Briefings',
+      contentType: 'Aggregated Full Text',
+      titleCount: 9
+    },
+    {
+      packageName: 'Country Reports & Profiles (EIU)',
+      contentType: 'Aggregated Full Text',
+      titleCount: 3
+    },
+    {
+      packageName: 'EIU CityData',
+      contentType: 'Online Reference',
+      titleCount: 1
+    },
+    {
+      packageName: 'EIU Complete Country Coverage',
+      contentType: 'Online Reference',
+      titleCount: 1
+    },
+    {
+      packageName: 'EIU: Country Reports Archive (DFG Nationallizenz)',
+      contentType: 'Aggregated Full Text',
+      titleCount: 2
+    }
+  ]);
+
+  createVendor('Edinburgh University Press', [
+    {
+      packageName: 'Digimap Ordnance Survey',
+      contentType: 'Online Reference',
+      titleCount: 1
+    },
+    {
+      packageName: 'Edinburch University Press',
+      contentType: 'E-Journal',
+      titleCount: 2
+    },
+    {
+      packageName: 'Edinburgh University Press (NESLi2)',
+      contentType: 'E-Journal',
+      titleCount: 3
+    },
+    {
+      packageName: 'Edinburgh University Press (SHEDL)',
+      contentType: 'E-Journal',
+      titleCount: 2
+    },
+    {
+      packageName: 'Edinburgh University Press Complete Collection (JISC)',
+      contentType: 'E-Journal',
+      titleCount: 6
+    },
+    {
+      packageName: 'Edinburgh University Press Complete Collection (SHEDL)',
+      contentType: 'E-Journal',
+      titleCount: 3
+    }
+  ]);
+
   server.createList('vendor', 5, 'withPackagesAndTitles', {
     packagesTotal: () => Math.floor(Math.random() * 10) + 1
   });
-
-  // function createVendor(name, packages = []) {
-  //   let vendor = server.create('vendor', {
-  //     vendorName: name,
-  //     packagesTotal: 0
-  //   });
-  //   packages.forEach((pkg)=> {
-  //     server.create('package', { ...pkg, vendor });
-  //   });
-  //
-  // }
-  //
-  //
-  // createVendor('Economist Intelligence Unit', [
-  //   {
-  //     packageName: 'Business Briefings',
-  //     contentType: 'Aggregated Full Text',
-  //     titleCount: 9
-  //   },
-  //   {
-  //     packageName: 'Country Reports & Profiles (EIU)',
-  //     contentType: 'Aggregated Full Text',
-  //     titleCount: 393
-  //   },
-  //   {
-  //     packageName: 'EIU CityData',
-  //     contentType: 'Online Reference',
-  //     titleCount: 1
-  //   },
-  //   {
-  //     packageName: 'EIU Complete Country Coverage',
-  //     contentType: 'Online Reference',
-  //     titleCount: 1
-  //   },
-  //   {
-  //     packageName: 'EIU: Country Reports Archive (DFG Nationallizenz)',
-  //     contentType: 'Aggregated Full Text',
-  //     titleCount: 193
-  //   }
-  // ]);
-  //
-  // createVendor('Edinburgh University Press', [
-  //   {
-  //     packageName: 'Digimap Ordnance Survey',
-  //     contentType: 'Online Reference',
-  //     titleCount: 1
-  //   },
-  //   {
-  //     packageName: 'Edinburch University Press',
-  //     contentType: 'E-Journal',
-  //     titleCount: 49
-  //   },
-  //   {
-  //     packageName: 'Edinburgh University Press (NESLi2)',
-  //     contentType: 'E-Journal',
-  //     titleCount: 44
-  //   },
-  //   {
-  //     packageName: 'Edinburgh University Press (SHEDL)',
-  //     contentType: 'E-Journal',
-  //     titleCount: 44
-  //   },
-  //   {
-  //     packageName: 'Edinburgh University Press Complete Collection (JISC)',
-  //     contentType: 'E-Journal',
-  //     titleCount: 48
-  //   },
-  //   {
-  //     packageName: 'Edinburgh University Press Complete Collection (SHEDL)',
-  //     contentType: 'E-Journal',
-  //     titleCount: 46
-  //   }
-  // ]);
-
-
 }


### PR DESCRIPTION
Makes the demo vendor and package data setup work again, with far fewer titles being created.

![localhost-3000-](https://user-images.githubusercontent.com/230597/29383227-3b32a424-8295-11e7-936f-2c063c3db5bb.png)
