### PR TITLE
Talk to Okapi

### DIFF
--- a/demo/stripes.config.js
+++ b/demo/stripes.config.js
@@ -1,17 +1,9 @@
 const path = require('path');
 
 module.exports = {
-  okapi: { 'url':'http://localhost:9130', 'tenant':'diku' },
+  okapi: { 'url':'http://okapi.frontside.io', 'tenant':'fs' },
   config: {
-    // autoLogin: { username: 'diku_admin', password: 'admin' }
-    // logCategories: 'core,redux,connect,connect-fetch,substitute,path,mpath,mquery,action,event,perm,interface,xhr'
-    // logPrefix: 'stripes'
-    // logTimestamp: false
-    // showPerms: false
-    // listInvisiblePerms: false
-    // disableAuth: false
     hasAllPerms: true,
-    // softLogout: false
     disableAuth: true
   },
   modules: {

--- a/mirage/index.js
+++ b/mirage/index.js
@@ -9,9 +9,8 @@ let start = () => {};
 // protect this require with an if statement so that webpack won't attempt to
 // bundle mirage at all.
 //
-// if (process.env.NODE_ENV !== 'production') {
-//   start = require('./start').default;
-// }
-start = require('./start').default;
+if (process.env.NODE_ENV !== 'production') {
+  start = require('./start').default;
+}
 
 export default start;

--- a/mirage/serializers/application.js
+++ b/mirage/serializers/application.js
@@ -1,4 +1,4 @@
-import { Serializer } from 'mirage-server';
+import { Serializer, pluralize } from 'mirage-server';
 
 export default Serializer.extend({
   embed: false,
@@ -30,7 +30,13 @@ export default Serializer.extend({
   },
 
   keyForCollection(modelName) {
-    return `${this.keyForModel(modelName)}List`;
+    const pluralizedKey = pluralize(this.keyForModel(modelName));
+
+    if (modelName === 'vendor' || modelName === 'title') {
+      return pluralizedKey;
+    } else {
+      return `${pluralizedKey}List`;
+    }
   },
 
   keyForEmbeddedRelationship(attributeName) {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
   "stripes": {
     "type": "app",
     "displayName": "e-holdings",
-    "route": "/eholdings"
+    "route": "/eholdings",
+    "okapiInterfaces": {
+      "kb-ebsco": "0.1.0"
+    }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,8 @@ export default class EHoldings extends Component {
     }).isRequired,
     match: PropTypes.shape({
       path: PropTypes.string.isRequired
-    }).isRequired
+    }).isRequired,
+    okapi: PropTypes.object
   }
 
   constructor(props) {

--- a/src/routes/customer-resource/customer-resource-show.js
+++ b/src/routes/customer-resource/customer-resource-show.js
@@ -45,8 +45,8 @@ export default class CustomerResourceShowRoute extends Component {
     }
 
     return showCustomerResource.records.find((title) => {
-      return title.titleId === titleId && title.customerResourcesList.some((pkgTitle) => {
-        return pkgTitle.packageId === packageId && pkgTitle.vendorId === vendorId;
+      return title.titleId == titleId && title.customerResourcesList.some((pkgTitle) => {
+        return pkgTitle.packageId == packageId && pkgTitle.vendorId == vendorId;
       });
     });
   }

--- a/src/routes/package/package-show.js
+++ b/src/routes/package/package-show.js
@@ -30,8 +30,8 @@ export default class PackageShowRoute extends Component {
     },
     showPackageTitles: {
       type: 'okapi',
-      path: 'eholdings/vendors/:{vendorId}/packages/:{packageId}/titles',
-      records: 'titleList',
+      path: 'eholdings/vendors/:{vendorId}/packages/:{packageId}/titles?search=%00&searchfield=titlename&offset=1&count=25&orderby=relevance',
+      records: 'titles',
       pk: 'titleId'
     }
   });
@@ -55,7 +55,7 @@ export default class PackageShowRoute extends Component {
     }
 
     return showPackage.records.find((pkg) => {
-      return pkg.packageId === packageId && pkg.vendorId === vendorId;
+      return pkg.packageId == packageId && pkg.vendorId == vendorId;
     });
   }
 
@@ -71,7 +71,7 @@ export default class PackageShowRoute extends Component {
 
     return showPackageTitles.records.filter((title) => {
       return title.customerResourcesList.some((pkgTitle) => {
-        return pkgTitle.packageId === packageId;
+        return pkgTitle.packageId == packageId;
       });
     });
   }

--- a/src/routes/search/search-vendors.js
+++ b/src/routes/search/search-vendors.js
@@ -24,8 +24,8 @@ export default class SearchVendors extends Component {
   static manifest = Object.freeze({
     searchVendors: {
       type: 'okapi',
-      path: 'eholdings/vendors?search=?{search}',
-      records: 'vendorList',
+      path: 'eholdings/vendors?search=?{search}&count=25&offset=1&orderby=relevance',
+      records: 'vendors',
       pk: 'vendorId'
     }
   });

--- a/src/routes/title/title-show.js
+++ b/src/routes/title/title-show.js
@@ -41,7 +41,7 @@ export default class TitleShowRoute extends Component {
     }
 
     return showTitle.records.find((title) => {
-      return title.titleId === titleId;
+      return title.titleId == titleId;
     });
   }
 }

--- a/src/routes/vendor/vendor-show.js
+++ b/src/routes/vendor/vendor-show.js
@@ -29,8 +29,8 @@ export default class VendorShowRoute extends Component {
     },
     showVendorPackages: {
       type: 'okapi',
-      path: 'eholdings/vendors/:{vendorId}/packages',
-      records: 'packageList',
+      path: 'eholdings/vendors/:{vendorId}/packages?search=%00&count=25&offset=1&orderby=relevance',
+      records: 'packagesList',
       pk: 'packageId'
     }
   });
@@ -54,7 +54,7 @@ export default class VendorShowRoute extends Component {
     }
 
     return showVendor.records.find((vendor) => {
-      return vendor.vendorId === vendorId;
+      return vendor.vendorId == vendorId;
     });
   }
 
@@ -69,7 +69,7 @@ export default class VendorShowRoute extends Component {
     }
 
     return showVendorPackages.records.filter((pkg) => {
-      return pkg.vendorId === vendorId;
+      return pkg.vendorId == vendorId;
     });
   }
 }


### PR DESCRIPTION
This PR points ui-eholdings towards `okapi.frontside.io` and turns off mirage when running in production.  Mirage serializer was updated to reflect recent changes in RM-API.

For now, required query params are hardcoded for demo purposes.