### PR TITLE
Crude Searches

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -13,7 +13,16 @@ export default function () {
   // fetch polyfill needs this header set so it can reliably set `response.url`
   const getHeaders = (req) => ({ 'X-Request-URL': req.url });
 
-    // Package resources
+  // Package resources
+  this.get('/packages', ({ packages }, request) => {
+    const filteredPackages = packages.all().filter((packageModel) => {
+      const query = request.queryParams.search.toLowerCase();
+      return packageModel.packageName.toLowerCase().includes(query);
+    });
+
+    return new Response(200, getHeaders(request), filteredPackages);
+  });
+
   this.get('/vendors/:vendorId/packages/:packageId', ({ packages }, request) => {
     const vendorPackage = packages.findBy({
       vendorId: request.params.vendorId,
@@ -39,6 +48,15 @@ export default function () {
   });
 
   // Title resources
+  this.get('/titles', ({ titles }, request) => {
+    const filteredTitles = titles.all().filter((titleModel) => {
+      const query = request.queryParams.search.toLowerCase();
+      return titleModel.titleName.toLowerCase().includes(query);
+    });
+
+    return new Response(200, getHeaders(request), filteredTitles);
+  });
+
   this.get('/titles/:id', ({ titles }, request) => {
     const title = titles.find(request.params.id);
     return new Response(200, getHeaders(request), title);

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { Route, Switch, Redirect } from 'react-router-dom';
 
 import SearchVendors from './routes/search/search-vendors';
+import SearchPackages from './routes/search/search-packages';
+import SearchTitles from './routes/search/search-titles';
 import VendorShow from './routes/vendor/vendor-show';
 import PackageShow from './routes/package/package-show';
 import CustomerResourceShow from './routes/customer-resource/customer-resource-show';
@@ -22,6 +24,8 @@ export default class EHoldings extends Component {
   constructor(props) {
     super(props);
     this.SearchVendors = props.stripes.connect(SearchVendors);
+    this.SearchPackages = props.stripes.connect(SearchPackages);
+    this.SearchTitles = props.stripes.connect(SearchTitles);
     this.VendorShow = props.stripes.connect(VendorShow);
     this.PackageShow = props.stripes.connect(PackageShow);
     this.CustomerResourceShow = props.stripes.connect(CustomerResourceShow);
@@ -34,6 +38,8 @@ export default class EHoldings extends Component {
     return(
       <Switch>
         <Route path={`${rootPath}/vendors`} exact component={this.SearchVendors}/>
+        <Route path={`${rootPath}/packages`} exact component={this.SearchPackages}/>
+        <Route path={`${rootPath}/titles`} exact component={this.SearchTitles}/>
         <Route path={`${rootPath}/vendors/:vendorId`} exact component={this.VendorShow}/>
         <Route path={`${rootPath}/vendors/:vendorId/packages/:packageId`} exact component={this.PackageShow}/>
         <Route path={`${rootPath}/vendors/:vendorId/packages/:packageId/titles/:titleId`} exact component={this.CustomerResourceShow}/>

--- a/src/routes/search/search-packages.js
+++ b/src/routes/search/search-packages.js
@@ -1,0 +1,124 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import queryString from 'query-string';
+import { Link } from 'react-router-dom';
+import Paneset from '@folio/stripes-components/lib/Paneset';
+import Pane from '@folio/stripes-components/lib/Pane';
+
+export default class SearchVendors extends Component {
+  static propTypes = {
+    location: PropTypes.shape({
+      pathname: PropTypes.string.isRequired,
+      search: PropTypes.string
+    }).isRequired,
+    history: PropTypes.shape({
+      push: PropTypes.func.isRequired
+    }).isRequired,
+    resources: PropTypes.shape({
+      searchPackages: PropTypes.shape({
+        records: PropTypes.arrayOf(PropTypes.object)
+      })
+    }).isRequired
+  };
+
+  static manifest = Object.freeze({
+    searchPackages: {
+      type: 'okapi',
+      path: 'eholdings/packages?search=?{search}&count=25&offset=1&orderby=relevance',
+      records: 'packagesList',
+      pk: 'packageId'
+    }
+  });
+
+  constructor(props) {
+    super(props);
+
+    const query = queryString.parse(props.location.search);
+
+    this.state = {
+      search: query.search || '',
+      query
+    };
+  }
+
+  componentWillReceiveProps({ location }) {
+    if (location.search !== this.props.location.search) {
+      this.setState({ query: queryString.parse(location.search) });
+    }
+  }
+
+  handleSearch = (e) => {
+    const { search, query } = this.state;
+    const { location: { pathname }, history } = this.props;
+    const searchQuery = queryString.stringify({ ...query, search });
+
+    e.preventDefault();
+    history.push(`${pathname}?${searchQuery}`);
+  };
+
+  handleChange = (e) => {
+    this.setState({
+      search: e.target.value
+    });
+  };
+
+  getPackages() {
+    const { resources: { searchPackages } } = this.props;
+    if (!searchPackages) { return []; }
+    return searchPackages.records;
+  }
+
+  get isLoading() {
+    const { resources: { searchPackages } } = this.props;
+    return !searchPackages || searchPackages.isPending;
+  }
+
+  render () {
+    const { search, query } = this.state;
+
+    const packages = this.getPackages();
+    const hasSearchResults = packages && packages.length > 0;
+
+    return (
+      <div data-test-eholdings>
+        <Paneset>
+          <Pane
+              defaultWidth="100%"
+              header={(
+                <form onSubmit={this.handleSearch}>
+                  <input
+                      type="search"
+                      name="search"
+                      value={search}
+                      placeholder="Search for packages"
+                      data-test-search-field
+                      onChange={this.handleChange} />
+                  <button
+                      type="submit"
+                      disabled={!search}
+                      data-test-search-submit>
+                    Search
+                  </button>
+                </form>
+              )}>
+            {this.isLoading ? (
+              <p>...loading</p>
+            ) : (!hasSearchResults && query.search) ? (
+              <p data-test-search-no-results>
+                No results found for <strong>{`"${query.search}"`}</strong>.
+              </p>
+            ) : (
+              <ul data-test-search-results-list>
+                {hasSearchResults && packages.map((pkg) => (
+                  <li data-test-search-results-item key={pkg.packageId}>
+                    <Link to={`/eholdings/vendors/${pkg.vendorId}/packages/${pkg.packageId}`}>{pkg.packageName}</Link>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Pane>
+        </Paneset>
+      </div>
+    );
+  }
+}

--- a/src/routes/search/search-packages.js
+++ b/src/routes/search/search-packages.js
@@ -73,6 +73,28 @@ export default class SearchVendors extends Component {
     return !searchPackages || searchPackages.isPending;
   }
 
+  renderButtonGroup() {
+    const { location, history } = this.props;
+    const goTo = (url) => () => history.push(url);
+    const isActive = (url) => url === location.pathname;
+
+    const searchButtons = [
+      ['Vendors', '/eholdings/vendors'],
+      ['Packages', '/eholdings/packages'],
+      ['Titles', '/eholdings/titles']
+    ];
+
+    return (
+      <div style={{ float: 'left', marginRight: '1rem' }}>
+        {searchButtons.map(([label, url], i) => (
+          <button key={i} onClick={goTo(url)} disabled={isActive(url)}>
+            {label}
+          </button>
+        ))}
+      </div>
+    );
+  }
+
   render () {
     const { search, query } = this.state;
 
@@ -85,21 +107,24 @@ export default class SearchVendors extends Component {
           <Pane
               defaultWidth="100%"
               header={(
-                <form onSubmit={this.handleSearch}>
-                  <input
-                      type="search"
-                      name="search"
-                      value={search}
-                      placeholder="Search for packages"
-                      data-test-search-field
-                      onChange={this.handleChange} />
-                  <button
-                      type="submit"
-                      disabled={!search}
-                      data-test-search-submit>
-                    Search
-                  </button>
-                </form>
+                <div style={{ width: '100%' }}>
+                  {this.renderButtonGroup()}
+                  <form onSubmit={this.handleSearch}>
+                    <input
+                        type="search"
+                        name="search"
+                        value={search}
+                        placeholder="Search for packages"
+                        data-test-search-field
+                        onChange={this.handleChange} />
+                    <button
+                        type="submit"
+                        disabled={!search}
+                        data-test-search-submit>
+                      Search
+                    </button>
+                  </form>
+                </div>
               )}>
             {this.isLoading ? (
               <p>...loading</p>

--- a/src/routes/search/search-titles.js
+++ b/src/routes/search/search-titles.js
@@ -1,0 +1,124 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import queryString from 'query-string';
+import { Link } from 'react-router-dom';
+import Paneset from '@folio/stripes-components/lib/Paneset';
+import Pane from '@folio/stripes-components/lib/Pane';
+
+export default class SearchVendors extends Component {
+  static propTypes = {
+    location: PropTypes.shape({
+      pathname: PropTypes.string.isRequired,
+      search: PropTypes.string
+    }).isRequired,
+    history: PropTypes.shape({
+      push: PropTypes.func.isRequired
+    }).isRequired,
+    resources: PropTypes.shape({
+      searchTitles: PropTypes.shape({
+        records: PropTypes.arrayOf(PropTypes.object)
+      })
+    }).isRequired
+  };
+
+  static manifest = Object.freeze({
+    searchTitles: {
+      type: 'okapi',
+      path: 'eholdings/titles?search=?{search}&searchfield=titlename&count=25&offset=1&orderby=relevance',
+      records: 'titles',
+      pk: 'titleId'
+    }
+  });
+
+  constructor(props) {
+    super(props);
+
+    const query = queryString.parse(props.location.search);
+
+    this.state = {
+      search: query.search || '',
+      query
+    };
+  }
+
+  componentWillReceiveProps({ location }) {
+    if (location.search !== this.props.location.search) {
+      this.setState({ query: queryString.parse(location.search) });
+    }
+  }
+
+  handleSearch = (e) => {
+    const { search, query } = this.state;
+    const { location: { pathname }, history } = this.props;
+    const searchQuery = queryString.stringify({ ...query, search });
+
+    e.preventDefault();
+    history.push(`${pathname}?${searchQuery}`);
+  };
+
+  handleChange = (e) => {
+    this.setState({
+      search: e.target.value
+    });
+  };
+
+  getTitles() {
+    const { resources: { searchTitles } } = this.props;
+    if (!searchTitles) { return []; }
+    return searchTitles.records;
+  }
+
+  get isLoading() {
+    const { resources: { searchTitles } } = this.props;
+    return !searchTitles || searchTitles.isPending;
+  }
+
+  render () {
+    const { search, query } = this.state;
+
+    const titles = this.getTitles();
+    const hasSearchResults = titles && titles.length > 0;
+
+    return (
+      <div data-test-eholdings>
+        <Paneset>
+          <Pane
+              defaultWidth="100%"
+              header={(
+                <form onSubmit={this.handleSearch}>
+                  <input
+                      type="search"
+                      name="search"
+                      value={search}
+                      placeholder="Search for titles"
+                      data-test-search-field
+                      onChange={this.handleChange} />
+                  <button
+                      type="submit"
+                      disabled={!search}
+                      data-test-search-submit>
+                    Search
+                  </button>
+                </form>
+              )}>
+            {this.isLoading ? (
+              <p>...loading</p>
+            ) : (!hasSearchResults && query.search) ? (
+              <p data-test-search-no-results>
+                No results found for <strong>{`"${query.search}"`}</strong>.
+              </p>
+            ) : (
+              <ul data-test-search-results-list>
+                {hasSearchResults && titles.map((title) => (
+                  <li data-test-search-results-item key={title.titleId}>
+                    <Link to={`/eholdings/titles/${title.titleId}`}>{title.titleName}</Link>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Pane>
+        </Paneset>
+      </div>
+    );
+  }
+}

--- a/src/routes/search/search-titles.js
+++ b/src/routes/search/search-titles.js
@@ -73,6 +73,28 @@ export default class SearchVendors extends Component {
     return !searchTitles || searchTitles.isPending;
   }
 
+  renderButtonGroup() {
+    const { location, history } = this.props;
+    const goTo = (url) => () => history.push(url);
+    const isActive = (url) => url === location.pathname;
+
+    const searchButtons = [
+      ['Vendors', '/eholdings/vendors'],
+      ['Packages', '/eholdings/packages'],
+      ['Titles', '/eholdings/titles']
+    ];
+
+    return (
+      <div style={{ float: 'left', marginRight: '1rem' }}>
+        {searchButtons.map(([label, url], i) => (
+          <button key={i} onClick={goTo(url)} disabled={isActive(url)}>
+            {label}
+          </button>
+        ))}
+      </div>
+    );
+  }
+
   render () {
     const { search, query } = this.state;
 
@@ -85,21 +107,24 @@ export default class SearchVendors extends Component {
           <Pane
               defaultWidth="100%"
               header={(
-                <form onSubmit={this.handleSearch}>
-                  <input
-                      type="search"
-                      name="search"
-                      value={search}
-                      placeholder="Search for titles"
-                      data-test-search-field
-                      onChange={this.handleChange} />
-                  <button
-                      type="submit"
-                      disabled={!search}
-                      data-test-search-submit>
-                    Search
-                  </button>
-                </form>
+                <div style={{ width: '100%' }}>
+                  {this.renderButtonGroup()}
+                  <form onSubmit={this.handleSearch}>
+                    <input
+                        type="search"
+                        name="search"
+                        value={search}
+                        placeholder="Search for titles"
+                        data-test-search-field
+                        onChange={this.handleChange} />
+                    <button
+                        type="submit"
+                        disabled={!search}
+                        data-test-search-submit>
+                      Search
+                    </button>
+                  </form>
+                </div>
               )}>
             {this.isLoading ? (
               <p>...loading</p>

--- a/src/routes/search/search-vendors.js
+++ b/src/routes/search/search-vendors.js
@@ -73,6 +73,28 @@ export default class SearchVendors extends Component {
     return !searchVendors || searchVendors.isPending;
   }
 
+  renderButtonGroup() {
+    const { location, history } = this.props;
+    const goTo = (url) => () => history.push(url);
+    const isActive = (url) => url === location.pathname;
+
+    const searchButtons = [
+      ['Vendors', '/eholdings/vendors'],
+      ['Packages', '/eholdings/packages'],
+      ['Titles', '/eholdings/titles']
+    ];
+
+    return (
+      <div style={{ float: 'left', marginRight: '1rem' }}>
+        {searchButtons.map(([label, url], i) => (
+          <button key={i} onClick={goTo(url)} disabled={isActive(url)}>
+            {label}
+          </button>
+        ))}
+      </div>
+    );
+  }
+
   render () {
     const { search, query } = this.state;
 
@@ -85,21 +107,24 @@ export default class SearchVendors extends Component {
           <Pane
               defaultWidth="100%"
               header={(
-                <form onSubmit={this.handleSearch}>
-                  <input
-                      type="search"
-                      name="search"
-                      value={search}
-                      placeholder="Search for vendors"
-                      data-test-search-field
-                      onChange={this.handleChange} />
-                  <button
-                      type="submit"
-                      disabled={!search}
-                      data-test-search-submit>
-                    Search
-                  </button>
-                </form>
+                <div style={{ width: '100%' }}>
+                  {this.renderButtonGroup()}
+                  <form onSubmit={this.handleSearch}>
+                    <input
+                        type="search"
+                        name="search"
+                        value={search}
+                        placeholder="Search for vendors"
+                        data-test-search-field
+                        onChange={this.handleChange} />
+                    <button
+                        type="submit"
+                        disabled={!search}
+                        data-test-search-submit>
+                      Search
+                    </button>
+                  </form>
+                </div>
               )}>
             {this.isLoading ? (
               <p>...loading</p>


### PR DESCRIPTION
Thought maybe we could get packages and titles searches out before the demo.

**Lacking Tests** for the two new search pages. But since the vendor search tests are mostly skipped right now, I didn't think it would be too big of a deal.

These search pages should be refactored anyway. We will definitely write tests during that.

### Screenshots

![2017-08-17 13 10 42](https://user-images.githubusercontent.com/5005153/29426967-e3d143ca-834d-11e7-9934-5b98d1660940.gif)
