### PR TITLE
Introduce KeyValueLabel component

### DIFF
--- a/mirage/factories/package.js
+++ b/mirage/factories/package.js
@@ -41,5 +41,11 @@ export default Factory.extend({
       packageObj.vendor = vendor;
       packageObj.save();
     }
-  })
+  }),
+
+  afterCreate(packageObj) {
+    if(packageObj.vendor) {
+      packageObj.update('vendorName', packageObj.vendor.vendorName).save();
+    }
+  }
 });

--- a/src/components/customer-resource-show.js
+++ b/src/components/customer-resource-show.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import Paneset from '@folio/stripes-components/lib/Paneset';
 import Pane from '@folio/stripes-components/lib/Pane';
-import KeyValue from '@folio/stripes-components/lib/KeyValue';
+import KeyValueLabel from './key-value-label';
 
 export default function CustomerResourceShow({ customerResource }) {
   return (
@@ -12,21 +12,39 @@ export default function CustomerResourceShow({ customerResource }) {
         <Pane defaultWidth="100%">
           {customerResource ? (
             <div>
-              <h3 data-test-eholdings-customer-resource-show-vendor-name>
-                <Link to={`/eholdings/vendors/${customerResource.customerResourcesList[0].vendorId}`}>{customerResource.customerResourcesList[0].vendorName}</Link>
-              </h3>
-              <h3 data-test-eholdings-customer-resource-show-package-name>
-                <Link to={`/eholdings/vendors/${customerResource.customerResourcesList[0].vendorId}/packages/${customerResource.customerResourcesList[0].packageId}`}>{customerResource.customerResourcesList[0].packageName}</Link>
-              </h3>
-              <h1 data-test-eholdings-customer-resource-show-title-name>
-                {customerResource.titleName}
-              </h1>
-              <div data-test-eholdings-customer-resource-show-selected>
-                <KeyValue label="Selected" value={customerResource.customerResourcesList[0].isSelected ? 'Selected' : 'Not Selected'} />
+              <div style={{ margin: '2rem 0' }}>
+                <KeyValueLabel label="Resource">
+                  <h1 data-test-eholdings-customer-resource-show-title-name>
+                    {customerResource.titleName}
+                  </h1>
+                </KeyValueLabel>
               </div>
+
+              <KeyValueLabel label="Package">
+                <div data-test-eholdings-customer-resource-show-package-name>
+                  <Link to={`/eholdings/vendors/${customerResource.customerResourcesList[0].vendorId}/packages/${customerResource.customerResourcesList[0].packageId}`}>{customerResource.customerResourcesList[0].packageName}</Link>
+                </div>
+              </KeyValueLabel>
+
+              <KeyValueLabel label="Vendor">
+                <div data-test-eholdings-customer-resource-show-vendor-name>
+                  <Link to={`/eholdings/vendors/${customerResource.customerResourcesList[0].vendorId}`}>{customerResource.customerResourcesList[0].vendorName}</Link>
+                </div>
+              </KeyValueLabel>
+
+              <hr />
+
+              <KeyValueLabel label="Selected">
+                <div data-test-eholdings-customer-resource-show-selected>
+                  {customerResource.customerResourcesList[0].isSelected ? 'Yes' : 'No'}
+                </div>
+              </KeyValueLabel>
+
+              <hr />
+
               <div>
                 <Link to={`/eholdings/titles/${customerResource.titleId}`}>
-                  View other packages that include this title
+                  View all packages that include this title
                 </Link>
               </div>
             </div>

--- a/src/components/key-value-label/index.js
+++ b/src/components/key-value-label/index.js
@@ -1,0 +1,1 @@
+export { default } from './key-value-label';

--- a/src/components/key-value-label/key-value-label.css
+++ b/src/components/key-value-label/key-value-label.css
@@ -1,0 +1,16 @@
+.kv-label {
+  display: block;
+  font-size: .8em;
+  font-weight: bold;
+  margin-bottom: 0;
+  text-transform: Uppercase;
+  color: #333;
+}
+
+.kv-value h1 {
+  margin-top: 0;
+}
+
+.kv-root {
+  margin-bottom: 1rem;
+}

--- a/src/components/key-value-label/key-value-label.js
+++ b/src/components/key-value-label/key-value-label.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './key-value-label.css';
+
+export default function KeyValueLabel(props) {
+  return (
+    <div className={styles['kv-root']}>
+      <div className={styles['kv-label']}>{props.label}</div>
+      <div className={styles['kv-value']}>
+        {props.children}
+      </div>
+    </div>
+  );
+}
+
+KeyValueLabel.propTypes = {
+  label: PropTypes.string,
+  value: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
+  children: PropTypes.node
+};

--- a/src/components/package-show/package-show.js
+++ b/src/components/package-show/package-show.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom'
 import Paneset from '@folio/stripes-components/lib/Paneset';
 import Pane from '@folio/stripes-components/lib/Pane';
-import KeyValue from '@folio/stripes-components/lib/KeyValue';
+import KeyValueLabel from '../key-value-label';
 import List from '@folio/stripes-components/lib/List';
 import styles from './package-show.css';
 
@@ -15,7 +15,7 @@ export default function PackageShow({ vendorPackage, packageTitles }) {
       </h5>
       <div data-test-eholdings-package-details-title-selected>
         { /* assumes that customerResourcesList.length will always equal one */  }
-        <span>{item.customerResourcesList[0].isSelected ? 'Selected' : 'Unselected'}</span>
+        <span>{item.customerResourcesList[0].isSelected ? 'Selected' : 'Not Selected'}</span>
       </div>
     </li>
   );
@@ -26,24 +26,47 @@ export default function PackageShow({ vendorPackage, packageTitles }) {
         <Pane defaultWidth="100%">
           {vendorPackage ? (
             <div>
-              <h3 data-test-eholdings-package-details-vendor>
-                <Link to={`/eholdings/vendors/${vendorPackage.vendorId}`}>{vendorPackage.vendorName}</Link>
-              </h3>
-              <h1 data-test-eholdings-package-details-name>
-                {vendorPackage.packageName}
-              </h1>
-              <div data-test-eholdings-package-details-content-type>
-                <KeyValue label="Content Type" value={vendorPackage.contentType} />
+              <div style={{ margin: '2rem 0' }}>
+                <KeyValueLabel label="Package">
+                  <h1 data-test-eholdings-package-details-name>
+                    {vendorPackage.packageName}
+                  </h1>
+                </KeyValueLabel>
               </div>
-              <div data-test-eholdings-package-details-selected>
-                <KeyValue label="Selected" value={vendorPackage.isSelected ? 'Selected' : 'Not Selected'} />
-              </div>
-              <div data-test-eholdings-package-details-titles-total>
-                <KeyValue label="Total Titles" value={vendorPackage.titleCount} />
-              </div>
-              <div data-test-eholdings-package-details-titles-selected>
-                <KeyValue label="Selected Titles" value={vendorPackage.selectedCount} />
-              </div>
+
+              <KeyValueLabel label="Vendor">
+                <div data-test-eholdings-package-details-vendor>
+                  <Link to={`/eholdings/vendors/${vendorPackage.vendorId}`}>{vendorPackage.vendorName}</Link>
+                </div>
+              </KeyValueLabel>
+
+              <KeyValueLabel label="Content Type">
+                <div data-test-eholdings-package-details-content-type>
+                  {vendorPackage.contentType}
+                </div>
+              </KeyValueLabel>
+
+              <KeyValueLabel label="Titles Selected">
+                <div data-test-eholdings-package-details-titles-selected>
+                  {vendorPackage.selectedCount}
+                </div>
+              </KeyValueLabel>
+
+              <KeyValueLabel label="Total Titles">
+                <div data-test-eholdings-package-details-titles-total>
+                  {vendorPackage.titleCount}
+                </div>
+              </KeyValueLabel>
+
+              <hr />
+
+              <KeyValueLabel label="Selected">
+                <div data-test-eholdings-package-details-selected>
+                  {vendorPackage.isSelected ? 'Yes' : 'No'}
+                </div>
+              </KeyValueLabel>
+
+              <hr />
 
               {packageTitles && packageTitles.length ? (
                 <div>

--- a/src/components/title-show/title-show.js
+++ b/src/components/title-show/title-show.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom'
 import Paneset from '@folio/stripes-components/lib/Paneset';
 import Pane from '@folio/stripes-components/lib/Pane';
-import KeyValue from '@folio/stripes-components/lib/KeyValue';
+import KeyValueLabel from '../key-value-label';
 import List from '@folio/stripes-components/lib/List';
 import styles from './title-show.css';
 
@@ -14,7 +14,7 @@ export default function TitleShow({ title }) {
         <Link to={`/eholdings/vendors/${item.vendorId}/packages/${item.packageId}/titles/${item.titleId}`}>{item.packageName}</Link>
       </h5>
       <div data-test-eholdings-title-show-package-selected>
-        <span>{item.isSelected ? 'Selected' : 'Unselected'}</span>
+        <span>{item.isSelected ? 'Selected' : 'Not Selected'}</span>
      </div>
     </li>
   );
@@ -25,12 +25,21 @@ export default function TitleShow({ title }) {
         <Pane defaultWidth="100%">
           {title ? (
             <div>
-              <h1 data-test-eholdings-title-show-title-name>
-                {title.titleName}
-              </h1>
-              <div data-test-eholdings-title-show-publisher-name>
-                <KeyValue label="Publisher" value={title.publisherName} />
+              <div style={{ margin: '2rem 0' }}>
+                <KeyValueLabel label="Title">
+                  <h1 data-test-eholdings-title-show-title-name>
+                    {title.titleName}
+                  </h1>
+                </KeyValueLabel>
               </div>
+
+              <KeyValueLabel label="Publisher">
+                <div data-test-eholdings-title-show-publisher-name>
+                  {title.publisherName}
+                </div>
+              </KeyValueLabel>
+
+              <hr />
               <h3>Packages</h3>
               <List
                 itemFormatter={renderPackageListItem}

--- a/src/components/vendor-show/vendor-show.js
+++ b/src/components/vendor-show/vendor-show.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom'
 import Paneset from '@folio/stripes-components/lib/Paneset';
 import Pane from '@folio/stripes-components/lib/Pane';
-import KeyValue from '@folio/stripes-components/lib/KeyValue';
+import KeyValueLabel from '../key-value-label';
 import List from '@folio/stripes-components/lib/List';
 import styles from './vendor-show.css';
 
@@ -14,7 +14,7 @@ export default function VendorShow({ vendor, vendorPackages }) {
         <Link to={`/eholdings/vendors/${vendor.vendorId}/packages/${item.packageId}`}>{item.packageName}</Link>
       </h5>
       <div>
-        <span>{item.isSelected ? 'Selected' : 'Unselected' }</span>
+        <span>{item.isSelected ? 'Selected' : 'Not Selected' }</span>
         &nbsp;&bull;&nbsp;
         <span data-test-eholdings-vendor-details-package-num-titles>{item.selectedCount}</span>
         &nbsp;/&nbsp;
@@ -31,16 +31,27 @@ export default function VendorShow({ vendor, vendorPackages }) {
         <Pane defaultWidth="100%">
           {vendor ? (
             <div>
-              <h1 data-test-eholdings-vendor-details-name>
-                {vendor.vendorName}
-              </h1>
-              <div data-test-eholdings-vendor-details-packages-total>
-                <KeyValue label="Total Packages" value={vendor.packagesTotal} />
-              </div>
-              <div data-test-eholdings-vendor-details-packages-selected>
-                <KeyValue label="Packages Selected" value={vendor.packagesSelected} />
+              <div style={{ margin: '2rem 0' }}>
+                <KeyValueLabel label="Vendor">
+                  <h1 data-test-eholdings-vendor-details-name>
+                    {vendor.vendorName}
+                  </h1>
+                </KeyValueLabel>
               </div>
 
+              <KeyValueLabel label="Packages Selected">
+                <div data-test-eholdings-vendor-details-packages-selected>
+                  {vendor.packagesSelected}
+                </div>
+              </KeyValueLabel>
+
+              <KeyValueLabel label="Total Packages">
+                <div data-test-eholdings-vendor-details-packages-total>
+                  {vendor.packagesTotal}
+                </div>
+              </KeyValueLabel>
+
+              <hr />
               {vendorPackages && vendorPackages.length ? (
                 <div>
                   <h3>Packages</h3>

--- a/tests/customer-resource-show-test.js
+++ b/tests/customer-resource-show-test.js
@@ -43,7 +43,7 @@ describeApplication('CustomerResourceShow', function() {
     });
 
     it('displays if the customer resource is selected', function() {
-      expect(CustomerResourceShowPage.isSelected).to.equal(`Selected${customerResources[0].isSelected ? 'Selected' : 'Not Selected'}`);
+      expect(CustomerResourceShowPage.isSelected).to.equal(`${customerResources[0].isSelected ? 'Yes' : 'No'}`);
     });
   });
 

--- a/tests/package-show-test.js
+++ b/tests/package-show-test.js
@@ -35,19 +35,19 @@ describeApplication('PackageShow', function() {
     });
 
     it('displays whether or not the package is selected', function() {
-      expect(PackageShowPage.isSelected).to.equal(`Selected${vendorPackage.isSelected ? 'Selected' : 'Not Selected'}`);
+      expect(PackageShowPage.isSelected).to.equal(`${vendorPackage.isSelected ? 'Yes' : 'No'}`);
     });
 
     it('displays the content type', function(){
-      expect(PackageShowPage.contentType).to.equal('Content Typee-book');
+      expect(PackageShowPage.contentType).to.equal('e-book');
     });
 
     it('displays the total number of titles', function() {
-      expect(PackageShowPage.numTitles).to.equal(`Total Titles${vendorPackage.titleCount}`);
+      expect(PackageShowPage.numTitles).to.equal(`${vendorPackage.titleCount}`);
     });
 
     it('displays the number of selected titles', function() {
-      expect(PackageShowPage.numTitlesSelected).to.equal(`Selected Titles${vendorPackage.selectedCount}`);
+      expect(PackageShowPage.numTitlesSelected).to.equal(`${vendorPackage.selectedCount}`);
     });
 
     it('displays a list of titles', function() {

--- a/tests/title-show-test.js
+++ b/tests/title-show-test.js
@@ -29,7 +29,7 @@ describeApplication('TitleShow', function() {
     });
 
     it('displays the publisher name', function() {
-      expect(TitleShowPage.publisherName).to.equal('PublisherCool Publisher');
+      expect(TitleShowPage.publisherName).to.equal('Cool Publisher');
     });
 
     it('displays a list of customer resources', function() {

--- a/tests/vendor-show-test.js
+++ b/tests/vendor-show-test.js
@@ -29,11 +29,11 @@ describeApplication('VendorShow', function() {
     });
 
     it('displays the total number of packages', function() {
-      expect(VendorShowPage.numPackages).to.equal(`Total Packages${vendor.packagesTotal}`);
+      expect(VendorShowPage.numPackages).to.equal(`${vendor.packagesTotal}`);
     });
 
     it('displays the number of selected packages', function() {
-      expect(VendorShowPage.numPackagesSelected).to.equal(`Packages Selected${vendor.packagesSelected}`);
+      expect(VendorShowPage.numPackagesSelected).to.equal(`${vendor.packagesSelected}`);
     });
 
     it('displays a list of packages', function() {


### PR DESCRIPTION
The new `KeyValueLabel` component mimics stripes' `KeyValue`, but allows passing in an entire node instead of just a string. This enabled much clearer relationship hierarchy on detail pages and better testing through data attributes.

### Vendor
![localhost-3000-eholdings-vendors-1-packages-1-titles-1 iphone 5 2](https://user-images.githubusercontent.com/230597/29469178-c0e769ce-840c-11e7-96d8-0ca885b5bb39.png)

### Package
![localhost-3000-eholdings-vendors-1-packages-1-titles-1 iphone 5 1](https://user-images.githubusercontent.com/230597/29469176-c0d421ac-840c-11e7-83b4-940e6032670b.png)

### Title
![localhost-3000-eholdings-vendors-1-packages-1-titles-1 iphone 5 3](https://user-images.githubusercontent.com/230597/29469177-c0e62fd2-840c-11e7-9a28-2cf166fc1ffb.png)

### Resource ("Package Title")
![localhost-3000-eholdings-vendors-1-packages-1-titles-1 iphone 5](https://user-images.githubusercontent.com/230597/29469179-c107b9ae-840c-11e7-865e-dd40aac3b9e9.png)