### PR TITLE
Point ui-eholdings to https://okapi.frontside.io

### DIFF
--- a/demo/stripes.config.js
+++ b/demo/stripes.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 module.exports = {
-  okapi: { 'url':'http://okapi.frontside.io', 'tenant':'fs' },
+  okapi: { 'url':'https://okapi.frontside.io', 'tenant':'fs' },
   config: {
     hasAllPerms: true,
     disableAuth: true


### PR DESCRIPTION
https://okapi.frontside.io is now working with the correct certificate, so the last piece of the puzzle is to point https://folio.frontside.io at that location.