### PR TITLE
Upgrade stripes-core

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -6,6 +6,9 @@ export default function () {
   this.urlPrefix = okapi.url;
   this.get('/_/version', () => '0.0.0');
   this.get('/_/proxy/modules', []);
+  this.get('/saml/check', {
+    ssoEnabled: false
+  });
 
   // e-holdings endpoints
   this.namespace = 'eholdings';

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "karma start"
   },
   "devDependencies": {
-    "@folio/stripes-core": "thefrontside/stripes-core#reducers-cache",
+    "@folio/stripes-core": "thefrontside/stripes-core#master",
     "babel-core": "^6.25.0",
     "babel-loader": "^7.1.1",
     "babel-preset-env": "^1.6.0",

--- a/tests/harness.js
+++ b/tests/harness.js
@@ -8,6 +8,7 @@ import configureLogger from '@folio/stripes-core/src/configureLogger';
 import configureStore from '@folio/stripes-core/src/configureStore';
 import { discoverServices } from '@folio/stripes-core/src/discoverServices';
 import gatherActions from '@folio/stripes-core/src/gatherActions';
+import { setOkapiReady } from '@folio/stripes-core/src/okapiActions';
 
 import Root from '@folio/stripes-core/src/Root';
 
@@ -26,13 +27,16 @@ const actionNames = gatherActions();
 export default class TestHarness extends Component {
 
   componentWillMount() {
-    this.store = configureStore({ okapi });
     this.logger = configureLogger(config);
+    this.store = configureStore({ okapi }, this.logger);
     this.mirage = startMirage();
 
     this.history = createMemoryHistory();
 
     discoverServices(okapi.url, this.store);
+
+    // While we have disableAuth on, manually tell our app Okapi is ready
+    this.store.dispatch(setOkapiReady());
   }
 
   componentWillUnmount() {

--- a/tests/stripes.config.js
+++ b/tests/stripes.config.js
@@ -18,6 +18,7 @@ export const okapi = { url: 'https://okapi.com', tenant:'tests' };
 export const config = {
   // autoLogin: { username: 'diku_admin', password: 'admin' }
   // logCategories: 'core,redux,connect,connect-fetch,substitute,path,mpath,mquery,action,event,perm,interface,xhr'
+  logCategories: '',
   // logPrefix: 'stripes'
   // logTimestamp: false
   // showPerms: false


### PR DESCRIPTION
Brings in https://github.com/folio-org/stripes-core/pull/27 and https://github.com/folio-org/stripes-core/pull/33; keeps locked into the Frontside fork for now. We'll switch to upstream master with the next release tag.