### PR TITLE
[WIP] Select / deselect package titles (customer resources)

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -47,6 +47,18 @@ export default function () {
     return new Response(200, getHeaders(request), titles.find(matchingCustomerResource.titleId));
   });
 
+  this.put('/vendors/:vendorId/packages/:packageId/titles/:titleId', ({ customerResources, titles }, request) => {
+    const matchingCustomerResource = customerResources.findBy({
+      packageId: request.params.packageId,
+      titleId: request.params.titleId
+    });
+
+    let { isSelected } = JSON.parse(request.requestBody);
+    matchingCustomerResource.update('isSelected', isSelected).save();
+
+    return new Response(204, getHeaders(request), '');
+  });
+
   // Title resources
   this.get('/titles', ({ titles }, request) => {
     const filteredTitles = titles.all().filter((titleModel) => {

--- a/src/components/customer-resource-show.js
+++ b/src/components/customer-resource-show.js
@@ -5,30 +5,30 @@ import Paneset from '@folio/stripes-components/lib/Paneset';
 import Pane from '@folio/stripes-components/lib/Pane';
 import KeyValueLabel from './key-value-label';
 
-export default function CustomerResourceShow({ customerResource }) {
+export default function CustomerResourceShow({ model, toggleSelected }) {
   return (
     <div data-test-eholdings-customer-resource-show>
       <Paneset>
         <Pane defaultWidth="100%">
-          {customerResource ? (
+          {model.isLoaded ? (
             <div>
               <div style={{ margin: '2rem 0' }}>
                 <KeyValueLabel label="Resource">
                   <h1 data-test-eholdings-customer-resource-show-title-name>
-                    {customerResource.titleName}
+                    {model.titleName}
                   </h1>
                 </KeyValueLabel>
               </div>
 
               <KeyValueLabel label="Package">
                 <div data-test-eholdings-customer-resource-show-package-name>
-                  <Link to={`/eholdings/vendors/${customerResource.customerResourcesList[0].vendorId}/packages/${customerResource.customerResourcesList[0].packageId}`}>{customerResource.customerResourcesList[0].packageName}</Link>
+                  <Link to={`/eholdings/vendors/${model.vendorId}/packages/${model.packageId}`}>{model.packageName}</Link>
                 </div>
               </KeyValueLabel>
 
               <KeyValueLabel label="Vendor">
                 <div data-test-eholdings-customer-resource-show-vendor-name>
-                  <Link to={`/eholdings/vendors/${customerResource.customerResourcesList[0].vendorId}`}>{customerResource.customerResourcesList[0].vendorName}</Link>
+                  <Link to={`/eholdings/vendors/${model.vendorId}`}>{model.vendorName}</Link>
                 </div>
               </KeyValueLabel>
 
@@ -36,14 +36,18 @@ export default function CustomerResourceShow({ customerResource }) {
 
               <KeyValueLabel label="Selected">
                 <div data-test-eholdings-customer-resource-show-selected>
-                  {customerResource.customerResourcesList[0].isSelected ? 'Yes' : 'No'}
+                  <input type="checkbox" onChange={toggleSelected} disabled={model.isTogglingSelection} checked={model.isSelected} />
+                  {model.isSelected ? 'Yes' : 'No'}
+                  {model.isTogglingSelection ? (
+                    <span data-test-eholdings-customer-resource-show-is-selecting>...</span>) : ('')
+                  }
                 </div>
               </KeyValueLabel>
 
-              <hr />
+              <hr/>
 
               <div>
-                <Link to={`/eholdings/titles/${customerResource.titleId}`}>
+                <Link to={`/eholdings/titles/${model.titleId}`}>
                   View all packages that include this title
                 </Link>
               </div>
@@ -58,5 +62,6 @@ export default function CustomerResourceShow({ customerResource }) {
 }
 
 CustomerResourceShow.propTypes = {
-  customerResource: PropTypes.object
+  customerResource: PropTypes.object,
+  saveSelected: PropTypes.func
 };

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ export default class EHoldings extends Component {
     this.SearchTitles = props.stripes.connect(SearchTitles);
     this.VendorShow = props.stripes.connect(VendorShow);
     this.PackageShow = props.stripes.connect(PackageShow);
-    this.CustomerResourceShow = props.stripes.connect(CustomerResourceShow);
+    this.CustomerResourceShow = CustomerResourceShow;
     this.TitleShow = props.stripes.connect(TitleShow);
   }
 

--- a/src/routes/customer-resource/customer-resource-show.js
+++ b/src/routes/customer-resource/customer-resource-show.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import fetch from 'isomorphic-fetch';
+import { connect } from 'react-redux';
 
 import View from '../../components/customer-resource-show';
 
-export default class CustomerResourceShowRoute extends Component {
+class CustomerResourceShowRoute extends Component {
   static propTypes = {
     match: PropTypes.shape({
       params: PropTypes.shape({
@@ -12,42 +13,130 @@ export default class CustomerResourceShowRoute extends Component {
         titleId: PropTypes.string.isRequired,
         vendorId: PropTypes.string.isRequired
       }).isRequired
-    }).isRequired,
-    resources: PropTypes.shape({
-      showCustomerResource: PropTypes.shape({
-        records: PropTypes.arrayOf(PropTypes.object)
-      })
-    })
+    }).isRequired
   };
 
-  static manifest = Object.freeze({
-    showCustomerResource: {
-      type: 'okapi',
-      path: 'eholdings/vendors/:{vendorId}/packages/:{packageId}/titles/:{titleId}',
-      pk: 'titleId'
-    }
-  });
+  static contextTypes = {
+    addReducer: PropTypes.func.isRequired
+  }
+
+  componentWillMount() {
+    this.context.addReducer('customerResourceShow', function(state, action) {
+      switch (action.type) {
+      case 'CUSTOMER_RESOURCE_SHOW_LOADED':
+        let resource = action.record.customerResourcesList[0];
+        return {
+          ...state,
+          isLoaded: true,
+          isErrored: false,
+          titleName: action.record.titleName,
+          ...resource
+        };
+      case 'CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED':
+        return {
+          ...state,
+          isSelected: !state.isSelected,
+          isTogglingSelection: true
+        };
+        return state;
+      case 'CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED_RESOLVE':
+        return {
+          ...state,
+          isTogglingSelection: false
+        };
+      case 'CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED_REJECT':
+        return {
+          ...state,
+          isTogglingSelection: false,
+          isSelected: !state.isSelected
+        };
+      case 'CUSTOMER_RESOURCE_SHOW_ERROR':
+        return {
+          ...state,
+          toggleSelectionError: action.error
+        };
+      default:
+        return state ? state : null;
+      }
+    });
+
+    let { loadRecord, errorRecord } = this.props.dispatch;
+
+    fetch(this.props.endpoint, {headers: {'X-Okapi-Tenant': this.props.okapi.tenant}})
+      .then((response) => {
+        return response.json().then(loadRecord);
+      })
+      .catch(errorRecord);
+  }
 
   render() {
     return (
-      <View customerResource={this.getCustomerResource()}/>
+      <View
+        model={this.props.model}
+        toggleSelected={this.props.dispatch.toggleSelected}
+      />
     );
   }
-
-  getCustomerResource() {
-    const {
-      resources: { showCustomerResource },
-      match: { params: { vendorId, packageId, titleId } }
-    } = this.props;
-
-    if (!showCustomerResource) {
-      return null;
-    }
-
-    return showCustomerResource.records.find((title) => {
-      return title.titleId == titleId && title.customerResourcesList.some((pkgTitle) => {
-        return pkgTitle.packageId == packageId && pkgTitle.vendorId == vendorId;
-      });
-    });
-  }
 }
+
+function mapStateToProps(state) {
+  let { okapi, customerResourceShow } = state;
+  return {
+    okapi,
+    model: customerResourceShow || {
+      isLoaded: false,
+      isErrored: false
+    }
+  };
+}
+
+function mapDispatchToProps(dispatch, ownProps) {
+  return {
+    loadRecord(record) {
+      dispatch({
+        type: 'CUSTOMER_RESOURCE_SHOW_LOADED',
+        record
+      });
+    },
+    errorRecord(error) {
+      dispatch({
+        type: 'CUSTOMER_RESOURCE_SHOW_ERROR',
+        error
+      });
+    },
+    toggleSelected(event) {
+      dispatch(function(dispatch, getState) {
+        dispatch({ type: 'CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED'});
+        let state = getState();
+        let { okapi, customerResourceShow: { vendorId, packageId, titleId, isSelected } } = state;
+        let endpoint =  `${okapi.url}/eholdings/vendors/${vendorId}/packages/${packageId}/titles/${titleId}`;
+        // TODO: add tenant headers
+        let headers = {
+          'Content-Type': 'application/json',
+          'X-Okapi-Tenant': okapi.tenant
+        };
+        fetch(endpoint, {method: 'PUT', headers, body: JSON.stringify({ isSelected })})
+          .then((response)=> {
+            dispatch({
+              type: 'CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED_RESOLVE'
+            });
+          })
+          .catch((error)=> {
+            dispatch({
+              type: 'CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED_REJECT',
+              error
+            });
+          });
+      });
+    }
+  };
+}
+
+function mergeProps(stateProps, dispatchProps, ownProps) {
+  let { okapi, model } = stateProps;
+  let { vendorId, packageId, titleId } = ownProps.match.params;
+  let { match } = ownProps;
+  return { endpoint: `${okapi.url}/eholdings/vendors/${vendorId}/packages/${packageId}/titles/${titleId}`, okapi, model, match, dispatch: dispatchProps };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(CustomerResourceShowRoute);

--- a/tests/customer-resource-show-test.js
+++ b/tests/customer-resource-show-test.js
@@ -3,10 +3,10 @@ import { expect } from 'chai';
 import it from './it-will';
 
 import { describeApplication } from './helpers';
-import CustomerResourceShowPage from './pages/customer-resource-show';
+import ResourcePage from './pages/customer-resource-show';
 
 describeApplication('CustomerResourceShow', function() {
-  let vendor, vendorPackage, customerResources;
+  let vendor, vendorPackage, resource;
 
   beforeEach(function() {
     vendor = this.server.create('vendor', {
@@ -20,32 +20,79 @@ describeApplication('CustomerResourceShow', function() {
       titleCount: 5
     });
 
-    customerResources = this.server.schema.where('customer-resource', { packageId: vendorPackage.id }).models;
+    resource = this.server.create('customer-resource', 'withTitle', {
+      package: vendorPackage,
+      isSelected: false
+    });
+
   });
 
   describe("visiting the customer resource page", function() {
     beforeEach(function() {
-      return this.visit(`/eholdings/vendors/${vendor.id}/packages/${vendorPackage.id}/titles/${customerResources[0].titleId}`, () => {
-        expect(CustomerResourceShowPage.$root).to.exist;
+      return this.visit(`/eholdings/vendors/${vendor.id}/packages/${vendorPackage.id}/titles/${resource.titleId}`, () => {
+        expect(ResourcePage.$root).to.exist;
       });
     });
 
     it('displays the vendor name', function() {
-      expect(CustomerResourceShowPage.vendorName).to.equal('Cool Vendor');
+      expect(ResourcePage.vendorName).to.equal('Cool Vendor');
     });
 
     it('displays the package name', function() {
-      expect(CustomerResourceShowPage.packageName).to.equal('Cool Package');
+      expect(ResourcePage.packageName).to.equal('Cool Package');
     });
 
     it('displays the title name', function() {
-      expect(CustomerResourceShowPage.titleName).to.equal(customerResources[0].title.titleName);
+      expect(ResourcePage.titleName).to.equal(resource.title.titleName);
     });
 
-    it('displays if the customer resource is selected', function() {
-      expect(CustomerResourceShowPage.isSelected).to.equal(`${customerResources[0].isSelected ? 'Yes' : 'No'}`);
+    it('indicates that the resource is not yet selected', function() {
+      expect(ResourcePage.isSelected).to.equal(false);
+    });
+
+    describe("selecting a package title to add to my holdings", function() {
+      beforeEach(function() {
+        ResourcePage.toggleIsSelected();
+      });
+
+      it('reflects the desired state (YES)', function() {
+        expect(ResourcePage.isSelected).to.equal(true);
+      });
+
+      it('indicates it working to get to desired state', function() {
+        expect(ResourcePage.isSelecting).to.equal(true);
+      });
+
+      it('cannot be interacted with while the request is in flight', function() {
+        expect(ResourcePage.isSelectedToggleable).to.equal(false);
+      });
+
+      describe('when the request succeeds', function() {
+        it('reflect the desired state was set', function() {
+          expect(ResourcePage.isSelected).to.equal(true);
+        });
+
+        it('indicates it is no longer working', function() {
+          expect(ResourcePage.isSelecting).to.equal(false);
+        });
+      });
+
+      describe('when the request fails', function() {
+        it('does not change to new state', function() {
+          expect(ResourcePage.isSelected).to.equal(false);
+        });
+
+        it('indicates it is no longer working', function() {
+          expect(ResourcePage.isSelecting).to.equal(false);
+        });
+
+        it.skip('logs an Error somewhere', function() {
+          expect(ResourcePage.flashError).to.match(/unable to select/i);
+        });
+      });
     });
   });
+
 
   describe.skip("encountering a server error", function() {
     beforeEach(function() {
@@ -55,13 +102,13 @@ describeApplication('CustomerResourceShow', function() {
         subcode: 0
       }], 500);
 
-      return this.visit(`/eholdings/vendors/${vendor.id}/packages/${vendorPackage.id}/titles/${customerResources[0].titleId}`, () => {
-        expect(CustomerResourceShowPage.$root).to.exist;
+      return this.visit(`/eholdings/vendors/${vendor.id}/packages/${vendorPackage.id}/titles/${resource.titleId}`, () => {
+        expect(ResourcePage.$root).to.exist;
       });
     });
 
     it("dies with dignity", function() {
-      expect(CustomerResourceShowPage.hasErrors).to.be.true;
+      expect(ResourcePage.hasErrors).to.be.true;
     });
   });
 });

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -27,7 +27,7 @@ export { default as triggerChange } from 'react-trigger-change';
  * @param {String} name - name of the test suite, passed to mocha's `describe`
  * @param {Function} setup - suite definition, also passed to `describe`
  */
-export function describeApplication(name, setup) {
+export function describeApplication(name, setup, describe = window.describe) {
   describe(name, function() {
     let rootElement;
 
@@ -54,6 +54,9 @@ export function describeApplication(name, setup) {
 }
 
 describeApplication.skip = describe.skip;
+describeApplication.only = function(name, setup) {
+  return describeApplication(name, setup, describe.only);
+};
 
 
 /**

--- a/tests/pages/customer-resource-show.js
+++ b/tests/pages/customer-resource-show.js
@@ -22,6 +22,22 @@ export default {
   },
 
   get isSelected() {
-    return $('[data-test-eholdings-customer-resource-show-selected]').text();
+    return $('[data-test-eholdings-customer-resource-show-selected]').text() === 'Yes';
+  },
+
+  toggleIsSelected() {
+    $('[data-test-eholdings-customer-resource-show-selected] input').click();
+  },
+
+  get isSelecting() {
+    return $('[data-test-eholdings-customer-resource-show-is-selecting]').length > 0;
+  },
+
+  get isSelectedToggleable() {
+    return $('[data-test-eholdings-customer-resource-show-selected] input[type=checkbox]').prop('disabled') === false;
+  },
+
+  get flashError() {
+    return '';
   }
 };


### PR DESCRIPTION
One of the primary use-cases for the e-holdings application is for digital resource librarians to manage their holdings. To do this they need the ability to mark a title as being part of their holdings (toggling it on and off);

This adds a reducer to the CustomerResourceShowRoute which handles all of the state changes. Currently, all of the side-effects are handled in `mapDispatchToProps`, but we should consider moving this over to using `redux-observable`.