### PR TITLE
Add custom coverage and hidden metadata to packages

### DIFF
--- a/mirage/factories/custom-coverage.js
+++ b/mirage/factories/custom-coverage.js
@@ -1,0 +1,6 @@
+import { Factory } from 'mirage-server';
+
+export default Factory.extend({
+  beginCoverage: null,
+  endCoverage: null
+});

--- a/mirage/factories/package.js
+++ b/mirage/factories/package.js
@@ -43,9 +43,20 @@ export default Factory.extend({
     }
   }),
 
-  afterCreate(packageObj) {
-    if(packageObj.vendor) {
-      packageObj.update('vendorName', packageObj.vendor.vendorName).save();
+  isHidden: trait({
+    afterCreate(packageObj, server) {
+      let visibilityData = server.create('visibility-data', {
+        isHidden: true,
+        reason: "The content is for mature audiences only."
+      });
+      packageObj.update('visibilityData', visibilityData);
+    }
+  }),
+
+  afterCreate(packageObj, server) {
+    if(!packageObj.visibilityData) {
+      let visibilityData = server.create('visibility-data');
+      packageObj.update('visibilityData', visibilityData);
     }
   }
 });

--- a/mirage/factories/package.js
+++ b/mirage/factories/package.js
@@ -53,7 +53,22 @@ export default Factory.extend({
     }
   }),
 
+  withCustomCoverage: trait({
+    afterCreate(packageObj, server) {
+      let customCoverage = server.create('custom-coverage', {
+        beginCoverage: () => faker.date.past(),
+        endCoverage: () => faker.date.future()
+      });
+      packageObj.update('customCoverage', customCoverage);
+    }
+  }),
+
   afterCreate(packageObj, server) {
+    if(!packageObj.customCoverage) {
+      let customCoverage = server.create('custom-coverage');
+      packageObj.update('customCoverage', customCoverage);
+    }
+
     if(!packageObj.visibilityData) {
       let visibilityData = server.create('visibility-data');
       packageObj.update('visibilityData', visibilityData);

--- a/mirage/factories/visibility-data.js
+++ b/mirage/factories/visibility-data.js
@@ -1,0 +1,6 @@
+import { Factory } from 'mirage-server';
+
+export default Factory.extend({
+  isHidden: false,
+  reason: ""
+});

--- a/mirage/models/custom-coverage.js
+++ b/mirage/models/custom-coverage.js
@@ -1,0 +1,3 @@
+import { Model } from 'mirage-server';
+
+export default Model.extend();

--- a/mirage/models/package.js
+++ b/mirage/models/package.js
@@ -1,6 +1,7 @@
 import { Model, belongsTo } from 'mirage-server';
 
 export default Model.extend({
+  customCoverage: belongsTo(),
   vendor: belongsTo(),
   visibilityData: belongsTo()
 });

--- a/mirage/models/package.js
+++ b/mirage/models/package.js
@@ -1,5 +1,6 @@
 import { Model, belongsTo } from 'mirage-server';
 
 export default Model.extend({
-  vendor: belongsTo()
+  vendor: belongsTo(),
+  visibilityData: belongsTo()
 });

--- a/mirage/models/visibility-data.js
+++ b/mirage/models/visibility-data.js
@@ -1,0 +1,3 @@
+import { Model } from 'mirage-server';
+
+export default Model.extend();

--- a/mirage/serializers/package.js
+++ b/mirage/serializers/package.js
@@ -1,0 +1,38 @@
+import { Serializer } from 'mirage-server';
+
+export default Serializer.extend({
+  embed: true,
+
+  include: ['visibilityData', 'vendor'],
+
+  serialize(response) {
+    let json = Serializer.prototype.serialize.apply(this, arguments);
+    let keyForPrimaryResource = this.keyForResource(response);
+    let unSideloadedJson = json[keyForPrimaryResource];
+
+    if (Array.isArray(unSideloadedJson)) {
+      return {
+        totalResults: unSideloadedJson.length,
+        packagesList: unSideloadedJson.map(this.adjustPackageKeys, this)
+      };
+    } else {
+      return this.adjustPackageKeys(unSideloadedJson);
+    }
+  },
+
+  adjustPackageKeys(json) {
+    // move the vendor id and name up a level
+    json.vendorId = json.vendor.id;
+    json.vendorName = json.vendor.vendorName;
+    delete json.vendor;
+
+    // delete ids of embedded records
+    delete json.visibilityData.id;
+
+    // rename primary id
+    json.packageId = json.id;
+    delete json.id;
+
+    return json;
+  }
+});

--- a/mirage/serializers/package.js
+++ b/mirage/serializers/package.js
@@ -3,7 +3,7 @@ import { Serializer } from 'mirage-server';
 export default Serializer.extend({
   embed: true,
 
-  include: ['visibilityData', 'vendor'],
+  include: ['customCoverage', 'vendor', 'visibilityData'],
 
   serialize(response) {
     let json = Serializer.prototype.serialize.apply(this, arguments);
@@ -27,6 +27,7 @@ export default Serializer.extend({
     delete json.vendor;
 
     // delete ids of embedded records
+    delete json.customCoverage.id;
     delete json.visibilityData.id;
 
     // rename primary id

--- a/src/components/package-show/package-show.js
+++ b/src/components/package-show/package-show.js
@@ -56,6 +56,14 @@ export default function PackageShow({ vendorPackage, packageTitles }) {
 
               <hr />
 
+              {vendorPackage.visibilityData.isHidden && (
+                <div data-test-eholdings-package-details-is-hidden>
+                <p><strong>This package is hidden.</strong></p>
+                <p><em>{vendorPackage.visibilityData.reason}</em></p>
+                <hr />
+                </div>
+              )}
+
               {packageTitles && packageTitles.length ? (
                 <div>
                   <h3>Titles</h3>

--- a/src/components/package-show/package-show.js
+++ b/src/components/package-show/package-show.js
@@ -46,6 +46,14 @@ export default function PackageShow({ vendorPackage, packageTitles }) {
                 </div>
               </KeyValueLabel>
 
+              {(vendorPackage.customCoverage.beginCoverage || vendorPackage.customCoverage.endCoverage) && (
+                <KeyValueLabel label="Custom Coverage">
+                  <div data-test-eholdings-package-details-custom-coverage>
+                    {vendorPackage.customCoverage.beginCoverage} - {vendorPackage.customCoverage.endCoverage}
+                  </div>
+                </KeyValueLabel>
+              )}
+
               <hr />
 
               <KeyValueLabel label="Selected">

--- a/tests/package-show-custom-coverage-test.js
+++ b/tests/package-show-custom-coverage-test.js
@@ -1,0 +1,58 @@
+/* global describe, beforeEach */
+import { expect } from 'chai';
+import it from './it-will';
+
+import { describeApplication } from './helpers';
+import PackageShowPage from './pages/package-show';
+
+describeApplication('PackageShowCustomCoverage', function() {
+  let vendor, pkg;
+
+  beforeEach(function() {
+    vendor = this.server.create('vendor', {
+      vendorName: 'Cool Vendor'
+    });
+  });
+
+  describe("visiting the package show page with custom coverage", function() {
+    beforeEach(function() {
+      let customCoverage = this.server.create('custom-coverage', {
+        beginCoverage: '1969-07-16',
+        endCoverage: '1972-12-19'
+      });
+
+      pkg = this.server.create('package', {
+        customCoverage,
+        vendor,
+        packageName: 'Cool Package',
+        contentType: 'e-book'
+      });
+
+      return this.visit(`/eholdings/vendors/${vendor.id}/packages/${pkg.id}`, () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    it('displays the custom coverage section', function() {
+      expect(PackageShowPage.customCoverage).to.equal('1969-07-16 - 1972-12-19');
+    });
+  });
+
+  describe("visiting the package show page with a package without custom coverage", function() {
+    beforeEach(function() {
+      pkg = this.server.create('package', {
+        vendor,
+        packageName: 'Cool Package',
+        contentType: 'e-book'
+      });
+
+      return this.visit(`/eholdings/vendors/${vendor.id}/packages/${pkg.id}`, () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    it('does not display the custom coverage section', function() {
+      expect(PackageShowPage.customCoverage).to.equal('');
+    });
+  });
+});

--- a/tests/package-show-visibility-test.js
+++ b/tests/package-show-visibility-test.js
@@ -1,0 +1,52 @@
+/* global describe, beforeEach */
+import { expect } from 'chai';
+import it from './it-will';
+
+import { describeApplication } from './helpers';
+import PackageShowPage from './pages/package-show';
+
+describeApplication('PackageShowVisibility', function() {
+  let vendor, pkg;
+
+  beforeEach(function() {
+    vendor = this.server.create('vendor', {
+      vendorName: 'Cool Vendor'
+    });
+  });
+
+  describe("visiting the package show page with a hidden package", function() {
+    beforeEach(function() {
+      pkg = this.server.create('package', 'isHidden', {
+        vendor,
+        packageName: 'Cool Package',
+        contentType: 'e-book'
+      });
+
+      return this.visit(`/eholdings/vendors/${vendor.id}/packages/${pkg.id}`, () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    it('displays the hidden/reason section', function() {
+      expect(PackageShowPage.isHidden).to.be.true;
+    });
+  });
+
+  describe("visiting the package show page with a package that is not hidden", function() {
+    beforeEach(function() {
+      pkg = this.server.create('package', {
+        vendor,
+        packageName: 'Cool Package',
+        contentType: 'e-book'
+      });
+
+      return this.visit(`/eholdings/vendors/${vendor.id}/packages/${pkg.id}`, () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    it('does not display the hidden/reason section', function() {
+      expect(PackageShowPage.isHidden).to.be.false;
+    });
+  });
+});

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -39,6 +39,10 @@ export default {
 
   get isHidden() {
     return $('[data-test-eholdings-package-details-is-hidden]').length === 1;
+  },
+
+  get customCoverage() {
+    return $('[data-test-eholdings-package-details-custom-coverage]').text();
   }
 };
 

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -35,6 +35,10 @@ export default {
 
   get titleList() {
     return $('[data-test-eholdings-package-details-title-list] li').toArray().map(createTitleObject);
+  },
+
+  get isHidden() {
+    return $('[data-test-eholdings-package-details-is-hidden]').length === 1;
   }
 };
 


### PR DESCRIPTION
Required a lot of custom serialization on the mirage side for packages, since `visibilityData`and `customCoverage` are essentially records embedded within a package.

### isHidden
![localhost-3000-eholdings-vendors-1- iphone 5](https://user-images.githubusercontent.com/230597/29793012-f69d3172-8c07-11e7-99e5-97bb2c829bcc.png)

### customCoverage
![localhost-3000-eholdings-vendors-1-packages-1 iphone 5](https://user-images.githubusercontent.com/230597/29793013-f6a7ff94-8c07-11e7-9a8e-150e9a8acb97.png)