### PR TITLE
Show package title content type

### DIFF
--- a/demo/stripes.config.js
+++ b/demo/stripes.config.js
@@ -4,7 +4,8 @@ module.exports = {
   okapi: { 'url':'https://okapi.frontside.io', 'tenant':'fs' },
   config: {
     hasAllPerms: true,
-    disableAuth: true
+    disableAuth: true,
+    logCategories: ''
   },
   modules: {
     '@folio/eholdings': {},

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -35,19 +35,15 @@ export default function () {
     return new Response(200, getHeaders(request), vendorPackage);
   });
 
-  this.get('/vendors/:vendorId/packages/:packageId/titles', ({ customerResources, titles }, request) => {
-    const matchingCustomerResources = customerResources.where({ packageId: request.params.packageId });
-    const titleIds = matchingCustomerResources.models.map((customerResource) => customerResource.titleId);
-    return new Response(200, getHeaders(request), titles.find(titleIds));
+  this.get('/vendors/:vendorId/packages/:packageId/titles', ({ customerResources }, request) => {
+    return new Response(200, getHeaders(request), customerResources.where({ packageId: request.params.packageId }));
   });
 
-  this.get('/vendors/:vendorId/packages/:packageId/titles/:titleId', ({ customerResources, titles }, request) => {
-    const matchingCustomerResource = customerResources.findBy({
+  this.get('/vendors/:vendorId/packages/:packageId/titles/:titleId', ({ customerResources }, request) => {
+    return new Response(200, getHeaders(request), customerResources.findBy({
       packageId: request.params.packageId,
       titleId: request.params.titleId
-    });
-
-    return new Response(200, getHeaders(request), titles.find(matchingCustomerResource.titleId));
+    }));
   });
 
   // Title resources

--- a/mirage/factories/customer-resource.js
+++ b/mirage/factories/customer-resource.js
@@ -16,23 +16,9 @@ export default Factory.extend({
     afterCreate(customerResource, server) {
       let packageObj = server.create('package', 'withVendor');
       customerResource.update({
-        'package': packageObj,
-        'packageName': packageObj.packageName,
-        'vendorId': packageObj.vendor.id,
-        'vendorName': packageObj.vendor.vendorName
+        'package': packageObj
       });
       customerResource.save();
     }
-  }),
-
-  afterCreate(customerResource) {
-    if(customerResource.package) {
-      customerResource.update({
-        'packageName': customerResource.package.packageName,
-        'vendorId': customerResource.package.vendor.id,
-        'vendorName': customerResource.package.vendor.vendorName
-      });
-      customerResource.save();
-    }
-  }
+  })
 });

--- a/mirage/serializers/application.js
+++ b/mirage/serializers/application.js
@@ -54,6 +54,7 @@ export default Serializer.extend({
       hash.vendorName = customerResource.package.vendor.vendorName;
       hash.packageId = customerResource.package.id;
       hash.packageName = customerResource.package.packageName;
+      hash.contentType = customerResource.package.contentType;
       hash.titleId = json.titleId;
       delete hash.package;
       delete hash.id;

--- a/mirage/serializers/customer-resource.js
+++ b/mirage/serializers/customer-resource.js
@@ -1,0 +1,31 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({
+  include: ['package', 'title'],
+
+  serialize() {
+    let json = ApplicationSerializer.prototype.serialize.apply(this, arguments);
+
+    if (Array.isArray(json.customerResources)) {
+      return {
+        totalResults: json.totalResults,
+        titles: json.customerResources
+      };
+    } else {
+      return json;
+    }
+  },
+
+  modifyKeys(json) {
+    if(json.title) {
+      let newHash = json.title;
+      newHash.customerResourcesList = this.createCustomerResourcesList(json.title);
+      delete newHash.customerResources;
+      newHash.titleId = json.title.id;
+      delete newHash.id;
+      return newHash;
+    } else {
+      return json;
+    }
+  }
+});

--- a/mirage/serializers/package.js
+++ b/mirage/serializers/package.js
@@ -1,39 +1,15 @@
-import { Serializer } from 'mirage-server';
+import ApplicationSerializer from './application';
 
-export default Serializer.extend({
-  embed: true,
-
+export default ApplicationSerializer.extend({
   include: ['customCoverage', 'vendor', 'visibilityData'],
 
-  serialize(response) {
-    let json = Serializer.prototype.serialize.apply(this, arguments);
-    let keyForPrimaryResource = this.keyForResource(response);
-    let unSideloadedJson = json[keyForPrimaryResource];
-
-    if (Array.isArray(unSideloadedJson)) {
-      return {
-        totalResults: unSideloadedJson.length,
-        packagesList: unSideloadedJson.map(this.adjustPackageKeys, this)
-      };
-    } else {
-      return this.adjustPackageKeys(unSideloadedJson);
+  modifyKeys(json) {
+    let newHash = json;
+    if(newHash.vendor && !newHash.vendorId) {
+      newHash.vendorId = json.vendor.id;
+      newHash.vendorName = json.vendor.vendorName;
+      delete newHash.vendor;
     }
-  },
-
-  adjustPackageKeys(json) {
-    // move the vendor id and name up a level
-    json.vendorId = json.vendor.id;
-    json.vendorName = json.vendor.vendorName;
-    delete json.vendor;
-
-    // delete ids of embedded records
-    delete json.customCoverage.id;
-    delete json.visibilityData.id;
-
-    // rename primary id
-    json.packageId = json.id;
-    delete json.id;
-
-    return json;
+    return newHash;
   }
 });

--- a/mirage/serializers/title.js
+++ b/mirage/serializers/title.js
@@ -1,10 +1,13 @@
 import ApplicationSerializer from './application';
+// import createCustomerResourcesList from '../utils/create-customer-resource-list';
 
 export default ApplicationSerializer.extend({
-  /*
-   * Title records DO return embedded records, not just ids of the relationships.
-  */
-  embed: true,
-  serializeIds: 'never',
-  include: ['customerResources']
+  include: ['customerResources'],
+
+  modifyKeys(json) {
+    let newHash = json;
+    newHash.customerResourcesList = this.createCustomerResourcesList(json);
+    delete newHash.customerResources;
+    return newHash;
+  }
 });

--- a/src/components/customer-resource-show.js
+++ b/src/components/customer-resource-show.js
@@ -26,6 +26,12 @@ export default function CustomerResourceShow({ customerResource }) {
                 </div>
               </KeyValueLabel>
 
+              <KeyValueLabel label="Content Type">
+                <div data-test-eholdings-customer-resource-show-content-type>
+                  {customerResource.customerResourcesList[0].contentType}
+                </div>
+              </KeyValueLabel>
+
               <KeyValueLabel label="Vendor">
                 <div data-test-eholdings-customer-resource-show-vendor-name>
                   <Link to={`/eholdings/vendors/${customerResource.customerResourcesList[0].vendorId}`}>{customerResource.customerResourcesList[0].vendorName}</Link>

--- a/src/routes/search/search-packages.js
+++ b/src/routes/search/search-packages.js
@@ -130,11 +130,11 @@ export default class SearchVendors extends Component {
             {this.isLoading ? (
               <p>...loading</p>
             ) : (!hasSearchResults && query.search) ? (
-              <p data-test-search-no-results>
+              <p data-test-package-search-no-results>
                 No results found for <strong>{`"${query.search}"`}</strong>.
               </p>
             ) : (
-              <ul data-test-search-results-list className={styles['search-results-list']}>
+              <ul data-test-package-search-results-list className={styles['search-results-list']}>
                 {hasSearchResults && packages.map((pkg) => (
                   <PackageListItem
                     key={pkg.packageId}

--- a/src/routes/search/search-titles.js
+++ b/src/routes/search/search-titles.js
@@ -130,11 +130,11 @@ export default class SearchVendors extends Component {
             {this.isLoading ? (
               <p>...loading</p>
             ) : (!hasSearchResults && query.search) ? (
-              <p data-test-search-no-results>
+              <p data-test-title-search-no-results>
                 No results found for <strong>{`"${query.search}"`}</strong>.
               </p>
             ) : (
-              <ul data-test-search-results-list className={styles['search-results-list']}>
+              <ul data-test-title-search-results-list className={styles['search-results-list']}>
                 {hasSearchResults && titles.map((title) => (
                   <TitleListItem
                     key={title.titleId}

--- a/src/routes/search/search-vendors.js
+++ b/src/routes/search/search-vendors.js
@@ -130,11 +130,11 @@ export default class SearchVendors extends Component {
             {this.isLoading ? (
               <p>...loading</p>
             ) : (!hasSearchResults && query.search) ? (
-              <p data-test-search-no-results>
+              <p data-test-vendor-search-no-results>
                 No results found for <strong>{`"${query.search}"`}</strong>.
               </p>
             ) : (
-              <ul data-test-search-results-list className={styles['search-results-list']}>
+              <ul data-test-vendor-search-results-list className={styles['search-results-list']}>
                 {hasSearchResults && vendors.map((vendor) => (
                   <VendorListItem
                     key={vendor.vendorId}

--- a/tests/customer-resource-show-test.js
+++ b/tests/customer-resource-show-test.js
@@ -42,6 +42,10 @@ describeApplication('CustomerResourceShow', function() {
       expect(CustomerResourceShowPage.titleName).to.equal(customerResources[0].title.titleName);
     });
 
+    it('displays the content type', function() {
+      expect(CustomerResourceShowPage.contentType).to.equal(customerResources[0].package.contentType);
+    });
+
     it('displays if the customer resource is selected', function() {
       expect(CustomerResourceShowPage.isSelected).to.equal(`${customerResources[0].isSelected ? 'Yes' : 'No'}`);
     });

--- a/tests/package-search-test.js
+++ b/tests/package-search-test.js
@@ -1,0 +1,52 @@
+/* global describe, beforeEach */
+import { expect } from 'chai';
+import it from './it-will';
+
+import { describeApplication } from './helpers';
+import SearchPackagesPage from './pages/search-packages';
+
+describeApplication('eHoldings', function() {
+  beforeEach(function() {
+    this.server.createList('package', 3, 'withVendor', {
+      packageName: (i) => `Package${i + 1}`
+    });
+
+    return this.visit('/eholdings/packages', () => {
+      expect(SearchPackagesPage.$root).to.exist;
+    });
+  });
+
+  it('has a searchbox', function() {
+    expect(SearchPackagesPage.$searchField).to.exist;
+  });
+
+  describe("searching for a package", function() {
+    beforeEach(function() {
+      SearchPackagesPage.search('Package');
+    });
+
+    it("displays package entries related to 'Package'", function() {
+      expect(SearchPackagesPage.$searchResultsItems).to.have.lengthOf(3);
+    });
+
+    describe("filtering the search results further", function() {
+      beforeEach(function() {
+        SearchPackagesPage.search('Package1');
+      });
+
+      it("only shows a single result", function() {
+        expect(SearchPackagesPage.$searchResultsItems).to.have.lengthOf(1);
+      });
+    });
+  });
+
+  describe("searching for the package 'fhqwhgads'", function() {
+    beforeEach(function() {
+      SearchPackagesPage.search('fhqwhgads');
+    });
+
+    it("displays 'no results' message", function() {
+      expect(SearchPackagesPage.noResultsMessage).to.equal('No results found for "fhqwhgads".');
+    });
+  });
+});

--- a/tests/pages/customer-resource-show.js
+++ b/tests/pages/customer-resource-show.js
@@ -17,6 +17,10 @@ export default {
     return $('[data-test-eholdings-customer-resource-show-package-name]').text();
   },
 
+  get contentType() {
+    return $('[data-test-eholdings-customer-resource-show-content-type]').text();
+  },
+
   get hasErrors() {
     return $('[data-test-eholdings-customer-resource-show-error]').length > 0;
   },

--- a/tests/pages/search-packages.js
+++ b/tests/pages/search-packages.js
@@ -11,7 +11,7 @@ export default {
   },
 
   get $searchResultsItems() {
-    return $('[data-test-vendor-search-results-list] li');
+    return $('[data-test-package-search-results-list] li');
   },
 
   get hasErrors() {
@@ -19,7 +19,7 @@ export default {
   },
 
   get noResultsMessage() {
-    return $('[data-test-vendor-search-no-results]').text();
+    return $('[data-test-package-search-no-results]').text();
   },
 
   search(query) {

--- a/tests/pages/search-titles.js
+++ b/tests/pages/search-titles.js
@@ -11,7 +11,7 @@ export default {
   },
 
   get $searchResultsItems() {
-    return $('[data-test-vendor-search-results-list] li');
+    return $('[data-test-title-search-results-list] li');
   },
 
   get hasErrors() {
@@ -19,7 +19,7 @@ export default {
   },
 
   get noResultsMessage() {
-    return $('[data-test-vendor-search-no-results]').text();
+    return $('[data-test-title-search-no-results]').text();
   },
 
   search(query) {

--- a/tests/title-search-test.js
+++ b/tests/title-search-test.js
@@ -1,0 +1,52 @@
+/* global describe, beforeEach */
+import { expect } from 'chai';
+import it from './it-will';
+
+import { describeApplication } from './helpers';
+import SearchTitlesPage from './pages/search-titles';
+
+describeApplication('eHoldings', function() {
+  beforeEach(function() {
+    this.server.createList('title', 3, {
+      titleName: (i) => `Title${i + 1}`
+    });
+
+    return this.visit('/eholdings/titles', () => {
+      expect(SearchTitlesPage.$root).to.exist;
+    });
+  });
+
+  it('has a searchbox', function() {
+    expect(SearchTitlesPage.$searchField).to.exist;
+  });
+
+  describe("searching for a title", function() {
+    beforeEach(function() {
+      SearchTitlesPage.search('Title');
+    });
+
+    it("displays title entries related to 'Title'", function() {
+      expect(SearchTitlesPage.$searchResultsItems).to.have.lengthOf(3);
+    });
+
+    describe("filtering the search results further", function() {
+      beforeEach(function() {
+        SearchTitlesPage.search('Title1');
+      });
+
+      it("only shows a single result", function() {
+        expect(SearchTitlesPage.$searchResultsItems).to.have.lengthOf(1);
+      });
+    });
+  });
+
+  describe("searching for the title 'fhqwhgads'", function() {
+    beforeEach(function() {
+      SearchTitlesPage.search('fhqwhgads');
+    });
+
+    it("displays 'no results' message", function() {
+      expect(SearchTitlesPage.noResultsMessage).to.equal('No results found for "fhqwhgads".');
+    });
+  });
+});

--- a/tests/title-show-test.js
+++ b/tests/title-show-test.js
@@ -37,7 +37,7 @@ describeApplication('TitleShow', function() {
     });
 
     it('displays name of a package in the customer resource list', function() {
-      expect(TitleShowPage.packageList[0].name).to.equal(customerResources[0].packageName);
+      expect(TitleShowPage.packageList[0].name).to.equal(customerResources[0].package.packageName);
     });
 
     it('displays whether the first customer resource is selected', function() {

--- a/tests/vendor-search-test.js
+++ b/tests/vendor-search-test.js
@@ -69,11 +69,11 @@ describeApplication('eHoldings', function() {
         subcode: 0
       }], 500);
 
-      AppPage.search("this doesn't matter");
+      SearchVendorsPage.search("this doesn't matter");
     });
 
     it("dies with dignity", function() {
-      expect(AppPage.hasErrors).to.be.true;
+      expect(SearchVendorsPage.hasErrors).to.be.true;
     });
   });
 });


### PR DESCRIPTION
It took a lot of mirage serialization refactoring to set up future `customerResource` embedded records that will needed for embargo/coverage data.

I added package and title search tests to aid in the refactoring.

Alternatives I explored with the mirage serializers:
- [_hashForModel()](https://github.com/samselikoff/ember-cli-mirage/blob/d93713e90957a62b40507d1fb988dba4d929a18e/addon/serializer.js#L208l) - it's "private" and I was running into circular problems with titles / customer-resources
- every model's serializer implements its own `serialize()` - there ended up being too much duplicated logic that could be abstracted up to the `ApplicationSerializer`

I ultimately chose to introduce the `modifyKeys()` pattern instead.

![localhost-3000-eholdings-vendors-1-packages-1-titles-1 iphone 5](https://user-images.githubusercontent.com/230597/29884742-fed0bd5a-8d79-11e7-9928-023bacf35cb0.png)
