### PR TITLE
Add pubType to titles

### DIFF
--- a/mirage/factories/title.js
+++ b/mirage/factories/title.js
@@ -3,6 +3,22 @@ import { Factory, faker, trait } from 'mirage-server';
 export default Factory.extend({
   titleName: () => faker.company.catchPhrase(),
   publisherName: () => faker.company.companyName(),
+  pubType: () => faker.random.arrayElement([
+    'Journal',
+    'Newsletter',
+    'Report',
+    'Proceedings',
+    'Website',
+    'Newspaper',
+    'Unspecified',
+    'Book',
+    'Book Series',
+    'Database',
+    'Thesis Dissertation',
+    'Streaming Audio',
+    'Streaming Video',
+    'Audiobook'
+  ]),
 
   withPackages: trait({
     afterCreate(title, server) {

--- a/src/components/customer-resource-show.js
+++ b/src/components/customer-resource-show.js
@@ -20,6 +20,18 @@ export default function CustomerResourceShow({ customerResource }) {
                 </KeyValueLabel>
               </div>
 
+              <KeyValueLabel label="Publisher">
+                <div data-test-eholdings-customer-resource-show-publisher-name>
+                  {customerResource.publisherName}
+                </div>
+              </KeyValueLabel>
+
+              <KeyValueLabel label="Publisher Type">
+                <div data-test-eholdings-customer-resource-show-publisher-type>
+                  {customerResource.pubType}
+                </div>
+              </KeyValueLabel>
+
               <KeyValueLabel label="Package">
                 <div data-test-eholdings-customer-resource-show-package-name>
                   <Link to={`/eholdings/vendors/${customerResource.customerResourcesList[0].vendorId}/packages/${customerResource.customerResourcesList[0].packageId}`}>{customerResource.customerResourcesList[0].packageName}</Link>
@@ -37,6 +49,13 @@ export default function CustomerResourceShow({ customerResource }) {
                   <Link to={`/eholdings/vendors/${customerResource.customerResourcesList[0].vendorId}`}>{customerResource.customerResourcesList[0].vendorName}</Link>
                 </div>
               </KeyValueLabel>
+
+              <KeyValueLabel label="Managed URL">
+                <div data-test-eholdings-customer-resource-show-managed-url>
+                  <Link to={customerResource.customerResourcesList[0].url}>{customerResource.customerResourcesList[0].url}</Link>
+                </div>
+              </KeyValueLabel>
+
 
               <hr />
 

--- a/src/components/title-show/title-show.js
+++ b/src/components/title-show/title-show.js
@@ -27,6 +27,12 @@ export default function TitleShow({ title }) {
                 </div>
               </KeyValueLabel>
 
+              <KeyValueLabel label="Publisher Type">
+                <div data-test-eholdings-title-show-publisher-type>
+                  {title.pubType}
+                </div>
+              </KeyValueLabel>
+
               <hr />
               <h3>Packages</h3>
               <ul data-test-eholdings-title-show-package-list className={styles['list']}>

--- a/tests/customer-resource-show-test.js
+++ b/tests/customer-resource-show-test.js
@@ -30,6 +30,18 @@ describeApplication('CustomerResourceShow', function() {
       });
     });
 
+    it('displays the title name', function() {
+      expect(CustomerResourceShowPage.titleName).to.equal(customerResources[0].title.titleName);
+    });
+
+    it('displays the publisher name', function() {
+      expect(CustomerResourceShowPage.publisherName).to.equal(customerResources[0].title.publisherName);
+    });
+
+    it('displays the publisher type', function() {
+      expect(CustomerResourceShowPage.publisherType).to.equal(customerResources[0].title.pubType);
+    });
+
     it('displays the vendor name', function() {
       expect(CustomerResourceShowPage.vendorName).to.equal('Cool Vendor');
     });
@@ -38,12 +50,12 @@ describeApplication('CustomerResourceShow', function() {
       expect(CustomerResourceShowPage.packageName).to.equal('Cool Package');
     });
 
-    it('displays the title name', function() {
-      expect(CustomerResourceShowPage.titleName).to.equal(customerResources[0].title.titleName);
-    });
-
     it('displays the content type', function() {
       expect(CustomerResourceShowPage.contentType).to.equal(customerResources[0].package.contentType);
+    });
+
+    it('displays the managed url', function() {
+      expect(CustomerResourceShowPage.managedUrl).to.equal(customerResources[0].url);
     });
 
     it('displays if the customer resource is selected', function() {

--- a/tests/pages/customer-resource-show.js
+++ b/tests/pages/customer-resource-show.js
@@ -9,6 +9,14 @@ export default {
     return $('[data-test-eholdings-customer-resource-show-title-name]').text();
   },
 
+  get publisherName() {
+    return $('[data-test-eholdings-customer-resource-show-publisher-name]').text();
+  },
+
+  get publisherType() {
+    return $('[data-test-eholdings-customer-resource-show-publisher-type]').text();
+  },
+
   get vendorName() {
     return $('[data-test-eholdings-customer-resource-show-vendor-name]').text();
   },
@@ -19,6 +27,10 @@ export default {
 
   get contentType() {
     return $('[data-test-eholdings-customer-resource-show-content-type]').text();
+  },
+
+  get managedUrl() {
+    return $('[data-test-eholdings-customer-resource-show-managed-url]').text();
   },
 
   get hasErrors() {

--- a/tests/pages/title-show.js
+++ b/tests/pages/title-show.js
@@ -13,6 +13,10 @@ export default {
     return $('[data-test-eholdings-title-show-publisher-name]').text();
   },
 
+  get publisherType() {
+    return $('[data-test-eholdings-title-show-publisher-type]').text();
+  },
+
   get hasErrors() {
     return $('[data-test-eholdings-title-show-error]').length > 0;
   },

--- a/tests/title-show-test.js
+++ b/tests/title-show-test.js
@@ -32,6 +32,10 @@ describeApplication('TitleShow', function() {
       expect(TitleShowPage.publisherName).to.equal('Cool Publisher');
     });
 
+    it('displays the publisher type', function() {
+      expect(TitleShowPage.publisherType).to.equal(title.pubType);
+    });
+
     it('displays a list of customer resources', function() {
       expect(TitleShowPage.packageList).to.have.lengthOf(customerResources.length);
     });


### PR DESCRIPTION
New additions:
- show publisher name and type, managed url on package-title detail
- show publisher type on title detail

![localhost-3000-eholdings-vendors-1-packages-1-titles-1 iphone 6](https://user-images.githubusercontent.com/230597/29933595-d0ef5e22-8e3d-11e7-86af-ac134ea7ea4a.png)
