### PR TITLE
[WIP] Use stripes to format date for locale

### DIFF
--- a/mirage/factories/package.js
+++ b/mirage/factories/package.js
@@ -56,8 +56,8 @@ export default Factory.extend({
   withCustomCoverage: trait({
     afterCreate(packageObj, server) {
       let customCoverage = server.create('custom-coverage', {
-        beginCoverage: () => faker.date.past(),
-        endCoverage: () => faker.date.future()
+        beginCoverage: () => faker.date.past().toISOString().substring(0,10),
+        endCoverage: () => faker.date.future().toISOString().substring(0,10)
       });
       packageObj.update('customCoverage', customCoverage);
     }

--- a/src/components/package-show/package-show.js
+++ b/src/components/package-show/package-show.js
@@ -7,7 +7,7 @@ import KeyValueLabel from '../key-value-label';
 import TitleListItem from '../title-list-item';
 import styles from './package-show.css';
 
-export default function PackageShow({ vendorPackage, packageTitles }) {
+export default function PackageShow({ vendorPackage, packageTitles }, { formatDate }) {
   return (
     <div data-test-eholdings-package-details>
       <Paneset>
@@ -49,7 +49,7 @@ export default function PackageShow({ vendorPackage, packageTitles }) {
               {(vendorPackage.customCoverage.beginCoverage || vendorPackage.customCoverage.endCoverage) && (
                 <KeyValueLabel label="Custom Coverage">
                   <div data-test-eholdings-package-details-custom-coverage>
-                    {vendorPackage.customCoverage.beginCoverage} - {vendorPackage.customCoverage.endCoverage}
+                    {formatDate(vendorPackage.customCoverage.beginCoverage)} - {formatDate(vendorPackage.customCoverage.endCoverage)}
                   </div>
                 </KeyValueLabel>
               )}
@@ -104,4 +104,8 @@ export default function PackageShow({ vendorPackage, packageTitles }) {
 PackageShow.propTypes = {
   vendorPackage: PropTypes.object,
   packageTitles: PropTypes.arrayOf(PropTypes.object)
+};
+
+PackageShow.contextTypes = {
+  formatDate: PropTypes.func
 };

--- a/src/index.js
+++ b/src/index.js
@@ -13,12 +13,25 @@ import TitleShow from './routes/title/title-show';
 export default class EHoldings extends Component {
   static propTypes = {
     stripes: PropTypes.shape({
-      connect: PropTypes.func.isRequired
+      connect: PropTypes.func.isRequired,
+      locale: PropTypes.string.isRequired
     }).isRequired,
     match: PropTypes.shape({
       path: PropTypes.string.isRequired
     }).isRequired,
     okapi: PropTypes.object
+  }
+
+  static childContextTypes = {
+    formatDate: PropTypes.func
+  }
+
+  getChildContext() {
+    return {
+      formatDate: (dateString) => {
+        return new Date(Date.parse(dateString)).toLocaleDateString(this.props.stripes.locale)
+      }
+    }
   }
 
   constructor(props) {

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,8 @@ export default class EHoldings extends Component {
   getChildContext() {
     return {
       formatDate: (dateString) => {
-        return new Date(Date.parse(dateString)).toLocaleDateString(this.props.stripes.locale)
+        // only for use with date strings not including time
+        return new Date(Date.parse(dateString)).toLocaleDateString(this.props.stripes.locale, { timezone: 'UTC' })
       }
     }
   }

--- a/tests/package-show-custom-coverage-test.js
+++ b/tests/package-show-custom-coverage-test.js
@@ -34,7 +34,7 @@ describeApplication('PackageShowCustomCoverage', function() {
     });
 
     it('displays the custom coverage section', function() {
-      expect(PackageShowPage.customCoverage).to.equal('1969-07-16 - 1972-12-19');
+      expect(PackageShowPage.customCoverage).to.equal('7/15/1969 - 12/18/1972');
     });
   });
 


### PR DESCRIPTION
I created a `formatDate()` available in the app's React context. It uses the locale defined by `stripes` to localize dates.