### PR TITLE
Format dates with react-intl

### DIFF
--- a/mirage/factories/package.js
+++ b/mirage/factories/package.js
@@ -56,8 +56,8 @@ export default Factory.extend({
   withCustomCoverage: trait({
     afterCreate(packageObj, server) {
       let customCoverage = server.create('custom-coverage', {
-        beginCoverage: () => faker.date.past(),
-        endCoverage: () => faker.date.future()
+        beginCoverage: () => faker.date.past().toISOString().substring(0,10),
+        endCoverage: () => faker.date.future().toISOString().substring(0,10)
       });
       packageObj.update('customCoverage', customCoverage);
     }

--- a/src/components/package-show.js
+++ b/src/components/package-show.js
@@ -8,7 +8,16 @@ import KeyValueLabel from './key-value-label';
 import List from './list';
 import TitleListItem from './title-list-item';
 
-export default function PackageShow({ vendorPackage, packageTitles }) {
+export default function PackageShow({ vendorPackage, packageTitles }, { intl }) {
+  let formatISODateWithoutTime = function(dateString) {
+    let [year, month, day]= dateString.split('-');
+    let dateObj = new Date();
+    dateObj.setFullYear(year);
+    dateObj.setMonth(parseInt(month, 10) - 1);
+    dateObj.setDate(day);
+    return intl.formatDate(dateObj);
+  };
+
   return (
     <div data-test-eholdings-package-details>
       <Paneset>
@@ -50,7 +59,7 @@ export default function PackageShow({ vendorPackage, packageTitles }) {
               {(vendorPackage.customCoverage.beginCoverage || vendorPackage.customCoverage.endCoverage) && (
                 <KeyValueLabel label="Custom Coverage">
                   <div data-test-eholdings-package-details-custom-coverage>
-                    {vendorPackage.customCoverage.beginCoverage} - {vendorPackage.customCoverage.endCoverage}
+                    {formatISODateWithoutTime(vendorPackage.customCoverage.beginCoverage)} - {formatISODateWithoutTime(vendorPackage.customCoverage.endCoverage)}
                   </div>
                 </KeyValueLabel>
               )}
@@ -104,4 +113,8 @@ export default function PackageShow({ vendorPackage, packageTitles }) {
 PackageShow.propTypes = {
   vendorPackage: PropTypes.object,
   packageTitles: PropTypes.arrayOf(PropTypes.object)
+};
+
+PackageShow.contextTypes = {
+  intl: PropTypes.object
 };

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,9 @@ export default class EHoldings extends Component {
   static propTypes = {
     match: PropTypes.shape({
       path: PropTypes.string.isRequired
+    }).isRequired,
+    stripes: PropTypes.shape({
+      intl: PropTypes.object.isRequired
     }).isRequired
   };
 
@@ -25,6 +28,16 @@ export default class EHoldings extends Component {
     addReducer: PropTypes.func.isRequired,
     addEpic: PropTypes.func.isRequired
   };
+
+  static childContextTypes = {
+    intl: PropTypes.object
+  }
+
+  getChildContext() {
+    return {
+      intl: this.props.stripes.intl
+    }
+  }
 
   constructor(props) {
     super(props);

--- a/tests/package-show-custom-coverage-test.js
+++ b/tests/package-show-custom-coverage-test.js
@@ -34,7 +34,7 @@ describeApplication('PackageShowCustomCoverage', function() {
     });
 
     it('displays the custom coverage section', function() {
-      expect(PackageShowPage.customCoverage).to.equal('1969-07-16 - 1972-12-19');
+      expect(PackageShowPage.customCoverage).to.equal('7/16/1969 - 12/19/1972');
     });
   });
 


### PR DESCRIPTION
Replaces https://github.com/thefrontside/ui-eholdings/pull/47

Stripes provides `intl`, so I made it available to our app via context. We don't have to know what the stripes `locale` is with this setup.

`formatISODateWithoutTime()` should be pulled out of the `PackageShow` component when it's needed in the `CustomerResourceShow` component.