### PR TITLE
Show identifiers for titles

### DIFF
--- a/mirage/factories/customer-resource.js
+++ b/mirage/factories/customer-resource.js
@@ -6,7 +6,7 @@ export default Factory.extend({
 
   withTitle: trait({
     afterCreate(customerResource, server) {
-      let title = server.create('title', 'withSubjects');
+      let title = server.create('title', 'withSubjects', 'withIdentifiers');
       customerResource.title = title;
       customerResource.save();
     }

--- a/mirage/factories/identifier.js
+++ b/mirage/factories/identifier.js
@@ -1,0 +1,7 @@
+import { Factory, faker } from 'mirage-server';
+
+export default Factory.extend({
+  id: () => faker.random.uuid(),
+  subtype: () => faker.random.number({ min: 0, max: 7 }),
+  type: () => faker.random.number({ min: 0, max: 9 })
+});

--- a/mirage/factories/title.js
+++ b/mirage/factories/title.js
@@ -46,5 +46,13 @@ export default Factory.extend({
       title.subjects = subjects;
       title.save();
     }
+  }),
+
+  withIdentifiers: trait({
+    afterCreate(title, server) {
+      let identifiers = server.createList('identifier', 3);
+      title.identifiers = identifiers;
+      title.save();
+    }
   })
 });

--- a/mirage/models/identifier.js
+++ b/mirage/models/identifier.js
@@ -1,0 +1,3 @@
+import { Model } from 'mirage-server';
+
+export default Model.extend();

--- a/mirage/models/title.js
+++ b/mirage/models/title.js
@@ -3,5 +3,6 @@ import { Model, hasMany, belongsTo } from 'mirage-server';
 export default Model.extend({
   package: belongsTo(),
   customerResources: hasMany(),
+  identifiers: hasMany(),
   subjects: hasMany()
 });

--- a/mirage/serializers/application.js
+++ b/mirage/serializers/application.js
@@ -47,7 +47,9 @@ export default Serializer.extend({
   },
 
   keyForEmbeddedRelationship(attributeName) {
-    if(attributeName === 'subjects' || attributeName === 'customerResources') {
+    let attributeNamesToAppendList = ['customerResources', 'subjects', 'identifiers'];
+
+    if(attributeNamesToAppendList.includes(attributeName)) {
       return `${pluralize(attributeName)}List`;
     } else {
       return attributeName;

--- a/mirage/serializers/title.js
+++ b/mirage/serializers/title.js
@@ -2,7 +2,7 @@ import ApplicationSerializer from './application';
 // import createCustomerResourcesList from '../utils/create-customer-resource-list';
 
 export default ApplicationSerializer.extend({
-  include: ['customerResources', 'subjects'],
+  include: ['customerResources', 'subjects', 'identifiers'],
 
   modifyKeys(json) {
     let newHash = json;

--- a/src/components/customer-resource-show.js
+++ b/src/components/customer-resource-show.js
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import Paneset from '@folio/stripes-components/lib/Paneset';
 import Pane from '@folio/stripes-components/lib/Pane';
 import KeyValueLabel from './key-value-label';
+import IdentifiersList from './identifiers-list';
 
 export default function CustomerResourceShow({ model, toggleSelected }) {
   return (
@@ -31,6 +32,8 @@ export default function CustomerResourceShow({ model, toggleSelected }) {
                   {model.pubType}
                 </div>
               </KeyValueLabel>
+
+              <IdentifiersList data={model.identifiersList} />
 
               <KeyValueLabel label="Package">
                 <div data-test-eholdings-customer-resource-show-package-name>

--- a/src/components/identifiers-list.js
+++ b/src/components/identifiers-list.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import KeyValueLabel from './key-value-label';
+
+export default function IdentifiersList({ data }) {
+  let types = {
+    0: 'ISSN',
+    1: 'ISBN',
+    2: 'TSDID',
+    3: 'SPID',
+    4: 'EjsJournaID',
+    5: 'NewsbankID',
+    6: 'ZDBID',
+    7: 'EPBookID',
+    8: 'Mid',
+    9: 'BHM'
+  };
+
+  let subtypes = {
+    0: 'Empty',
+    1: 'Print',
+    2: 'Online',
+    3: 'Preceding',
+    4: 'Succeeding',
+    5: 'Regional',
+    6: 'Linking',
+    7: 'Invalid'
+  };
+
+  // turn type and subtype ids into strings
+  let identifiersWithCompoundTypes = data.map((identifier) => {
+    let compoundType = types[identifier.type];
+
+    if(identifier.subtype > 0) {
+      compoundType = `${compoundType} (${subtypes[identifier.subtype]})`;
+    }
+
+    return {
+      id: identifier.id,
+      compoundType
+    }
+  });
+
+  // group by type/subtype combination
+  let identifiersByType = identifiersWithCompoundTypes.reduce(function (byType, identifier) {
+    let key = identifier.compoundType;
+    byType[key] = byType[key] || [];
+    byType[key].push(identifier.id);
+    return byType;
+  }, {});
+
+  return (
+    <div>
+      {Object.keys(identifiersByType).map((key) => {
+        return (
+          <div key={key} data-test-eholdings-identifiers-list-item>
+            <KeyValueLabel label={key}>
+              {identifiersByType[key].join(' ')}
+            </KeyValueLabel>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+IdentifiersList.propTypes = {
+  data: PropTypes.array
+};

--- a/src/components/title-show/title-show.js
+++ b/src/components/title-show/title-show.js
@@ -4,6 +4,7 @@ import Paneset from '@folio/stripes-components/lib/Paneset';
 import Pane from '@folio/stripes-components/lib/Pane';
 import KeyValueLabel from '../key-value-label';
 import PackageListItem from '../package-list-item';
+import IdentifiersList from '../identifiers-list';
 import styles from './title-show.css';
 
 export default function TitleShow({ title }) {
@@ -32,6 +33,8 @@ export default function TitleShow({ title }) {
                   {title.pubType}
                 </div>
               </KeyValueLabel>
+
+              <IdentifiersList data={title.identifiersList} />
 
               {title.subjectsList.length > 0 && (
                 <KeyValueLabel label="Subjects">

--- a/tests/pages/title-show.js
+++ b/tests/pages/title-show.js
@@ -17,6 +17,10 @@ export default {
     return $('[data-test-eholdings-title-show-publication-type]').text();
   },
 
+  get identifiersList() {
+    return $('[data-test-eholdings-identifiers-list-item]').toArray().map((item) => $(item).text());
+  },
+
   get subjectsList() {
     return $('[data-test-eholdings-title-show-subjects-list]').text();
   },

--- a/tests/title-show-test.js
+++ b/tests/title-show-test.js
@@ -19,6 +19,12 @@ describeApplication('TitleShow', function() {
       this.server.create('subject', { subject: 'Cool Subject 2' }),
       this.server.create('subject', { subject: 'Cool Subject 3' })
     ];
+    title.identifiers = [
+      this.server.create('identifier', { type: 1, subtype: 1, id: '978-0547928210' }),
+      this.server.create('identifier', { type: 1, subtype: 1, id: '978-0547928203' }),
+      this.server.create('identifier', { type: 1, subtype: 2, id: '978-0547928197' }),
+      this.server.create('identifier', { type: 1, subtype: 0, id: '978-0547928227' })
+    ]
     title.save();
 
     customerResources = title.customerResources.models;
@@ -41,6 +47,18 @@ describeApplication('TitleShow', function() {
 
     it('displays the publication type', function() {
       expect(TitleShowPage.publicationType).to.equal(title.pubType);
+    });
+
+    it('groups together identifiers of the same type and subtype', function() {
+      expect(TitleShowPage.identifiersList[0]).to.equal('ISBN (Print)978-0547928210 978-0547928203');
+    });
+
+    it('does not group together identifiers of the same type, but not the same subtype', function() {
+      expect(TitleShowPage.identifiersList[1]).to.equal('ISBN (Online)978-0547928197');
+    });
+
+    it('does not show a subtype for an identifier when none exists', function() {
+      expect(TitleShowPage.identifiersList[2]).to.equal('ISBN978-0547928227');
     });
 
     it('displays the subjects list', function() {


### PR DESCRIPTION
Adds identifiers (ISSN, ISBN, etc.) to title and package-title detail views.

Implemented following guidelines here: https://issues.folio.org/browse/UIEH-30

![localhost-3000-eholdings-vendors-1-packages-1-titles-1 iphone 5 1](https://user-images.githubusercontent.com/230597/30127636-98e2b926-9305-11e7-8fae-921deba13bbe.png)
