### PR TITLE
Select / deselect package titles (customer resources)

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -46,6 +46,18 @@ export default function () {
     }));
   });
 
+  this.put('/vendors/:vendorId/packages/:packageId/titles/:titleId', ({ customerResources, titles }, request) => {
+    let matchingCustomerResource = customerResources.findBy({
+      packageId: request.params.packageId,
+      titleId: request.params.titleId
+    });
+
+    let { isSelected } = JSON.parse(request.requestBody);
+    matchingCustomerResource.update('isSelected', isSelected).save();
+
+    return new Response(200, getHeaders(request), '');
+  });
+
   // Title resources
   this.get('/titles', ({ titles }, request) => {
     const filteredTitles = titles.all().filter((titleModel) => {

--- a/mirage/models/title.js
+++ b/mirage/models/title.js
@@ -1,6 +1,7 @@
-import { Model, hasMany } from 'mirage-server';
+import { Model, hasMany, belongsTo } from 'mirage-server';
 
 export default Model.extend({
+  package: belongsTo(),
   customerResources: hasMany(),
   subjects: hasMany()
 });

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "webpack-dev-server": "^2.5.0"
   },
   "dependencies": {
-    "isomorphic-fetch": "^2.2.1"
+    "isomorphic-fetch": "^2.2.1",
+    "redux-actions": "^2.2.1"
   },
   "stripes": {
     "type": "app",

--- a/src/components/customer-resource-show.js
+++ b/src/components/customer-resource-show.js
@@ -5,63 +5,63 @@ import Paneset from '@folio/stripes-components/lib/Paneset';
 import Pane from '@folio/stripes-components/lib/Pane';
 import KeyValueLabel from './key-value-label';
 
-export default function CustomerResourceShow({ customerResource }) {
+export default function CustomerResourceShow({ model, toggleSelected }) {
   return (
     <div data-test-eholdings-customer-resource-show>
       <Paneset>
         <Pane defaultWidth="100%">
-          {customerResource ? (
+          {model.isLoaded ? (
             <div>
               <div style={{ margin: '2rem 0' }}>
                 <KeyValueLabel label="Resource">
                   <h1 data-test-eholdings-customer-resource-show-title-name>
-                    {customerResource.titleName}
+                    {model.titleName}
                   </h1>
                 </KeyValueLabel>
               </div>
 
               <KeyValueLabel label="Publisher">
                 <div data-test-eholdings-customer-resource-show-publisher-name>
-                  {customerResource.publisherName}
+                  {model.publisherName}
                 </div>
               </KeyValueLabel>
 
               <KeyValueLabel label="Publication Type">
                 <div data-test-eholdings-customer-resource-show-publication-type>
-                  {customerResource.pubType}
+                  {model.pubType}
                 </div>
               </KeyValueLabel>
 
               <KeyValueLabel label="Package">
                 <div data-test-eholdings-customer-resource-show-package-name>
-                  <Link to={`/eholdings/vendors/${customerResource.customerResourcesList[0].vendorId}/packages/${customerResource.customerResourcesList[0].packageId}`}>{customerResource.customerResourcesList[0].packageName}</Link>
+                  <Link to={`/eholdings/vendors/${model.vendorId}/packages/${model.packageId}`}>{model.packageName}</Link>
                 </div>
               </KeyValueLabel>
 
               <KeyValueLabel label="Content Type">
                 <div data-test-eholdings-customer-resource-show-content-type>
-                  {customerResource.customerResourcesList[0].contentType}
+                  {model.contentType}
                 </div>
               </KeyValueLabel>
 
               <KeyValueLabel label="Vendor">
                 <div data-test-eholdings-customer-resource-show-vendor-name>
-                  <Link to={`/eholdings/vendors/${customerResource.customerResourcesList[0].vendorId}`}>{customerResource.customerResourcesList[0].vendorName}</Link>
+                  <Link to={`/eholdings/vendors/${model.vendorId}`}>{model.vendorName}</Link>
                 </div>
               </KeyValueLabel>
 
-              {customerResource.customerResourcesList[0].url && (
+              {model.url && (
                 <KeyValueLabel label="Managed URL">
                   <div data-test-eholdings-customer-resource-show-managed-url>
-                    <Link to={customerResource.customerResourcesList[0].url}>{customerResource.customerResourcesList[0].url}</Link>
+                    <Link to={model.url}>{model.url}</Link>
                   </div>
                 </KeyValueLabel>
               ) }
 
-              {customerResource.subjectsList.length > 0 && (
+              {model.subjectsList && model.subjectsList.length > 0 && (
                 <KeyValueLabel label="Subjects">
                   <div data-test-eholdings-customer-resource-show-subjects-list>
-                    {customerResource.subjectsList.map((subjectObj) => subjectObj.subject).join('; ')}
+                    {model.subjectsList.map((subjectObj) => subjectObj.subject).join('; ')}
                   </div>
                 </KeyValueLabel>
               ) }
@@ -70,14 +70,18 @@ export default function CustomerResourceShow({ customerResource }) {
 
               <KeyValueLabel label="Selected">
                 <div data-test-eholdings-customer-resource-show-selected>
-                  {customerResource.customerResourcesList[0].isSelected ? 'Yes' : 'No'}
+                  <input type="checkbox" onChange={toggleSelected} disabled={model.isTogglingSelection} checked={model.isSelected} />
+                  {model.isSelected ? 'Yes' : 'No'}
+                  {model.isTogglingSelection ? (
+                    <span data-test-eholdings-customer-resource-show-is-selecting>...</span>) : ('')
+                  }
                 </div>
               </KeyValueLabel>
 
-              <hr />
+              <hr/>
 
               <div>
-                <Link to={`/eholdings/titles/${customerResource.titleId}`}>
+                <Link to={`/eholdings/titles/${model.titleId}`}>
                   View all packages that include this title
                 </Link>
               </div>
@@ -92,5 +96,6 @@ export default function CustomerResourceShow({ customerResource }) {
 }
 
 CustomerResourceShow.propTypes = {
-  customerResource: PropTypes.object
+  model: PropTypes.object,
+  saveSelected: PropTypes.func
 };

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ export default class EHoldings extends Component {
     this.SearchTitles = props.stripes.connect(SearchTitles);
     this.VendorShow = props.stripes.connect(VendorShow);
     this.PackageShow = props.stripes.connect(PackageShow);
-    this.CustomerResourceShow = props.stripes.connect(CustomerResourceShow);
+    this.CustomerResourceShow = CustomerResourceShow;
     this.TitleShow = props.stripes.connect(TitleShow);
   }
 

--- a/src/routes/customer-resource/customer-resource-show.js
+++ b/src/routes/customer-resource/customer-resource-show.js
@@ -1,10 +1,28 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import fetch from 'isomorphic-fetch';
+import { connect } from 'react-redux';
+import { handleActions } from 'redux-actions';
+import  { Observable }  from 'rxjs/Observable';
+import { bindActionCreators } from 'redux'
+
+import 'rxjs/add/observable/from';
+import 'rxjs/add/observable/of';
+import 'rxjs/add/operator/catch';
+import 'rxjs/add/operator/switchMap';
 
 import View from '../../components/customer-resource-show';
 
-export default class CustomerResourceShowRoute extends Component {
+const ActionTypes = {
+  'CUSTOMER_RESOURCE_SHOW_ERROR': 'CUSTOMER_RESOURCE_SHOW_ERROR',
+  'CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED_REJECT': 'CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED_REJECT',
+  'CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED_RESOLVE': 'CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED_RESOLVE',
+  'CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED': 'CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED',
+  'CUSTOMER_RESOURCE_SHOW_LOADED': 'CUSTOMER_RESOURCE_SHOW_LOADED',
+  'CUSTOMER_RESOURCE_SHOW_LOAD': 'CUSTOMER_RESOURCE_SHOW_LOAD'
+};
+
+class CustomerResourceShowRoute extends Component {
   static propTypes = {
     match: PropTypes.shape({
       params: PropTypes.shape({
@@ -12,42 +30,137 @@ export default class CustomerResourceShowRoute extends Component {
         titleId: PropTypes.string.isRequired,
         vendorId: PropTypes.string.isRequired
       }).isRequired
-    }).isRequired,
-    resources: PropTypes.shape({
-      showCustomerResource: PropTypes.shape({
-        records: PropTypes.arrayOf(PropTypes.object)
-      })
-    })
+    }).isRequired
   };
 
-  static manifest = Object.freeze({
-    showCustomerResource: {
-      type: 'okapi',
-      path: 'eholdings/vendors/:{vendorId}/packages/:{packageId}/titles/:{titleId}',
-      pk: 'titleId'
-    }
-  });
+  static contextTypes = {
+    addReducer: PropTypes.func.isRequired,
+    addEpic: PropTypes.func.isRequired
+  }
+
+
+  componentWillMount() {
+    let { okapi } = this.props;
+
+    let headers = {
+      'Content-Type': 'application/json',
+      'X-Okapi-Tenant': okapi.tenant
+    };
+
+
+    const ToggleSelectionEpic = (action$, { getState }) => (
+      action$.ofType(ActionTypes.CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED)
+        .switchMap((action) => {
+          let { endpoint, isSelected } = getState().customerResourceShow;
+          let body = JSON.stringify({isSelected: isSelected});
+          let request = fetch(endpoint, { headers, method: 'PUT', body });
+
+          return Observable.from(request.then(
+            (response) => {
+              if(!response.ok) {
+                throw Error(response.statusText)
+              }
+              return response;
+            }
+          ))
+            .map(() => ({ type: ActionTypes.CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED_RESOLVE }))
+            .catch((error) => Observable.of({ type: ActionTypes.CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED_REJECT, error }));
+        })
+    );
+
+
+
+    const ResourceLoadedEpic = (action$, { getState }) => (
+      action$.ofType(ActionTypes.CUSTOMER_RESOURCE_SHOW_LOAD)
+        .switchMap((action) => {
+          let { endpoint } = getState().customerResourceShow;
+          let request = fetch(endpoint, { headers });
+
+          return Observable.from(request.then((response) => response.json()))
+            .map((json) => ({ type: ActionTypes.CUSTOMER_RESOURCE_SHOW_LOADED, payload: json }))
+            .catch((error) => Observable.of({ type: ActionTypes.CUSTOMER_RESOURCE_SHOW_ERROR, error }));
+        })
+    );
+
+    this.context.addEpic('customerResourceToggleSelected', ToggleSelectionEpic);
+    this.context.addEpic('customerResourceShowLoad', ResourceLoadedEpic);
+
+    this.context.addReducer('customerResourceShow', handleActions({
+      [ActionTypes.CUSTOMER_RESOURCE_SHOW_LOAD]: (state, action) => {
+        let { vendorId, packageId, titleId } = action.params;
+        let endpoint = `${okapi.url}/eholdings/vendors/${vendorId}/packages/${packageId}/titles/${titleId}`;
+        return {...state, endpoint};
+      },
+      [ActionTypes.CUSTOMER_RESOURCE_SHOW_LOADED]: (state, action) => {
+        let { customerResourcesList, ...title } = action.payload;
+        let resource = customerResourcesList[0];
+
+        return {
+          ...state,
+          isLoaded: true,
+          isErrored: false,
+          ...title,
+          ...resource
+        };
+      },
+      [ActionTypes.CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED]: (state, action) => {
+        return {
+          ...state,
+          isSelected: !state.isSelected,
+          isTogglingSelection: true
+        };
+      },
+      [ActionTypes.CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED_RESOLVE]: (state, action) => {
+        return {
+          ...state,
+          isTogglingSelection: false
+        };
+      },
+      [ActionTypes.CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED_REJECT]: (state, action) => {
+        return {
+          ...state,
+          isTogglingSelection: false,
+          isSelected: !state.isSelected
+        };
+      },
+      [ActionTypes.CUSTOMER_RESOURCE_SHOW_ERROR]: (state, action) => {
+        return {
+          ...state,
+          toggleSelectionError: action.error
+        };
+      }
+    }, { isLoaded: false, isErrored: false }));
+
+    this.props.loadRecord(this.props.match.params);
+  }
 
   render() {
+    let { vendorId, packageId, titleId } = this.props.match.params;
     return (
-      <View customerResource={this.getCustomerResource()}/>
+      <View
+        model={this.props.model}
+        toggleSelected={this.props.toggleSelected}
+      />
     );
   }
-
-  getCustomerResource() {
-    const {
-      resources: { showCustomerResource },
-      match: { params: { vendorId, packageId, titleId } }
-    } = this.props;
-
-    if (!showCustomerResource) {
-      return null;
-    }
-
-    return showCustomerResource.records.find((title) => {
-      return title.titleId == titleId && title.customerResourcesList.some((pkgTitle) => {
-        return pkgTitle.packageId == packageId && pkgTitle.vendorId == vendorId;
-      });
-    });
-  }
 }
+
+function mapStateToProps(state) {
+  let { okapi, customerResourceShow } = state;
+  return {
+    okapi,
+    model: customerResourceShow || {
+      isLoaded: false,
+      isErrored: false
+    }
+  };
+}
+
+const loadRecord = (params) => ({
+  type: 'CUSTOMER_RESOURCE_SHOW_LOAD', params
+});
+const toggleSelected = (event) => ({
+  type: 'CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED'
+});
+
+export default connect(mapStateToProps, { loadRecord, toggleSelected })(CustomerResourceShowRoute);

--- a/tests/harness.js
+++ b/tests/harness.js
@@ -3,7 +3,7 @@ import startMirage from '../mirage';
 
 import createMemoryHistory from 'history/createMemoryHistory';
 import { okapi, config } from 'stripes-loader';
-import epics from '@folio/stripes-core/src/epics';
+import configureEpics from '@folio/stripes-core/src/configureEpics';
 import configureLogger from '@folio/stripes-core/src/configureLogger';
 import configureStore from '@folio/stripes-core/src/configureStore';
 import { discoverServices } from '@folio/stripes-core/src/discoverServices';
@@ -28,7 +28,8 @@ export default class TestHarness extends Component {
 
   componentWillMount() {
     this.logger = configureLogger(config);
-    this.store = configureStore({ okapi }, this.logger);
+    this.epics = configureEpics();
+    this.store = configureStore({ okapi }, this.logger, this.epics);
     this.mirage = startMirage();
 
     this.history = createMemoryHistory();
@@ -46,7 +47,7 @@ export default class TestHarness extends Component {
   render() {
     return (
       <Root store={this.store}
-            epics={epics}
+            epics={this.epics}
             logger={this.logger}
             config={config}
             okapi={okapi}

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -27,7 +27,7 @@ export { default as triggerChange } from 'react-trigger-change';
  * @param {String} name - name of the test suite, passed to mocha's `describe`
  * @param {Function} setup - suite definition, also passed to `describe`
  */
-export function describeApplication(name, setup) {
+export function describeApplication(name, setup, describe = window.describe) {
   describe(name, function() {
     let rootElement;
 
@@ -54,6 +54,9 @@ export function describeApplication(name, setup) {
 }
 
 describeApplication.skip = describe.skip;
+describeApplication.only = function(name, setup) {
+  return describeApplication(name, setup, describe.only);
+};
 
 
 /**

--- a/tests/pages/customer-resource-show.js
+++ b/tests/pages/customer-resource-show.js
@@ -42,6 +42,22 @@ export default {
   },
 
   get isSelected() {
-    return $('[data-test-eholdings-customer-resource-show-selected]').text();
+    return $('[data-test-eholdings-customer-resource-show-selected]').text() === 'Yes';
+  },
+
+  toggleIsSelected() {
+    $('[data-test-eholdings-customer-resource-show-selected] input').click();
+  },
+
+  get isSelecting() {
+    return $('[data-test-eholdings-customer-resource-show-is-selecting]').length > 0;
+  },
+
+  get isSelectedToggleable() {
+    return $('[data-test-eholdings-customer-resource-show-selected] input[type=checkbox]').prop('disabled') === false;
+  },
+
+  get flashError() {
+    return '';
   }
 };


### PR DESCRIPTION
One of the primary use-cases for the e-holdings application is for
digital resource librarians to manage their holdings. To do this they
need the ability to mark a title as being part of their
holdings (toggling it on and off);

This work, along with recent changes to stripes-core, leverages the
concept of 'epics' from 'redux-observable' to ensure async actions
resolve sanely.