### PR TITLE
Use `triggerChange` for click event in customer-resource-show-test

### DIFF
--- a/tests/pages/customer-resource-show.js
+++ b/tests/pages/customer-resource-show.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import { triggerChange } from '../helpers';
 
 export default {
   get $root() {
@@ -46,7 +47,7 @@ export default {
   },
 
   toggleIsSelected() {
-    $('[data-test-eholdings-customer-resource-show-selected] input').click();
+    triggerChange($('[data-test-eholdings-customer-resource-show-selected] input').get(0));
   },
 
   get isSelecting() {


### PR DESCRIPTION
Invoking `.click()` directly seems to produce flakey results when simulating
a click event on the selection/deselection checkbox.  Using react-trigger-change
seems to produce more consistent results.