### PR TITLE
Show embargo periods for customer resources

### DIFF
--- a/mirage/factories/customer-resource.js
+++ b/mirage/factories/customer-resource.js
@@ -39,5 +39,23 @@ export default Factory.extend({
       customerResource.update('visibilityData', visibilityData);
       customerResource.save();
     }
+
+    if(!customerResource.customEmbargoPeriod) {
+      let customEmbargoPeriod = server.create('embargo-period', {
+        embargoUnit: null,
+        embargoValue: 0
+      });
+      customerResource.update('customEmbargoPeriod', customEmbargoPeriod);
+      customerResource.save();
+    }
+
+    if(!customerResource.managedEmbargoPeriod) {
+      let managedEmbargoPeriod = server.create('embargo-period', {
+        embargoUnit: null,
+        embargoValue: 0
+      });
+      customerResource.update('managedEmbargoPeriod', managedEmbargoPeriod);
+      customerResource.save();
+    }
   }
 });

--- a/mirage/factories/embargo-period.js
+++ b/mirage/factories/embargo-period.js
@@ -1,0 +1,11 @@
+import { Factory, faker } from 'mirage-server';
+
+export default Factory.extend({
+  embargoUnit: () => faker.random.arrayElement([
+    'Days',
+    'Weeks',
+    'Months',
+    'Years'
+  ]),
+  embargoValue: () => faker.random.number({ min: 0, max: 7 })
+});

--- a/mirage/models/customer-resource.js
+++ b/mirage/models/customer-resource.js
@@ -3,5 +3,7 @@ import { Model, belongsTo } from 'mirage-server';
 export default Model.extend({
   package: belongsTo(),
   title: belongsTo(),
-  visibilityData: belongsTo()
+  visibilityData: belongsTo(),
+  customEmbargoPeriod: belongsTo('embargo-period'),
+  managedEmbargoPeriod: belongsTo('embargo-period')
 });

--- a/mirage/models/embargo-period.js
+++ b/mirage/models/embargo-period.js
@@ -1,0 +1,3 @@
+import { Model } from 'mirage-server';
+
+export default Model.extend();

--- a/mirage/serializers/customer-resource.js
+++ b/mirage/serializers/customer-resource.js
@@ -1,7 +1,7 @@
 import ApplicationSerializer from './application';
 
 export default ApplicationSerializer.extend({
-  include: ['package', 'title', 'visibilityData'],
+  include: ['package', 'title', 'visibilityData', 'customEmbargoPeriod', 'managedEmbargoPeriod'],
 
   serialize() {
     let json = ApplicationSerializer.prototype.serialize.apply(this, arguments);

--- a/src/components/customer-resource-show.js
+++ b/src/components/customer-resource-show.js
@@ -72,6 +72,22 @@ export default function CustomerResourceShow({ model, toggleSelected }) {
                 </KeyValueLabel>
               ) }
 
+              {resource.managedEmbargoPeriod.embargoUnit && (
+                <KeyValueLabel label="Managed Embargo Period">
+                  <div data-test-eholdings-customer-resource-show-managed-embargo-period>
+                    {resource.managedEmbargoPeriod.embargoValue} {resource.managedEmbargoPeriod.embargoUnit}
+                  </div>
+                </KeyValueLabel>
+              ) }
+
+              {resource.customEmbargoPeriod.embargoUnit && (
+                <KeyValueLabel label="Custom Embargo Period">
+                  <div data-test-eholdings-customer-resource-show-custom-embargo-period>
+                    {resource.customEmbargoPeriod.embargoValue} {resource.customEmbargoPeriod.embargoUnit}
+                  </div>
+                </KeyValueLabel>
+              ) }
+
               <hr />
 
               <KeyValueLabel label="Selected">

--- a/tests/customer-resource-show-embargo-test.js
+++ b/tests/customer-resource-show-embargo-test.js
@@ -1,0 +1,63 @@
+/* global describe, beforeEach */
+import { expect } from 'chai';
+import it from './it-will';
+
+import { describeApplication } from './helpers';
+import CustomerResourceShowPage from './pages/customer-resource-show';
+
+describeApplication('CustomerResourceShowEmbargos', function() {
+  let pkg, title, resource;
+
+  beforeEach(function() {
+    pkg = this.server.create('package', 'withVendor');
+    title = this.server.create('title');
+    resource = this.server.create('customer-resource', {
+      package: pkg,
+      title
+    });
+  });
+
+  describe("visiting the customer resource show page with custom and managed embargos", function() {
+    beforeEach(function() {
+      resource.managedEmbargoPeriod = this.server.create('embargo-period', {
+        embargoUnit: 'Months',
+        embargoValue: 6
+      });
+
+      resource.customEmbargoPeriod = this.server.create('embargo-period', {
+        embargoUnit: 'Weeks',
+        embargoValue: 9
+      });
+
+      resource.save();
+
+      return this.visit(`/eholdings/vendors/${pkg.vendor.id}/packages/${pkg.id}/titles/${resource.id}`, () => {
+        expect(CustomerResourceShowPage.$root).to.exist;
+      });
+    });
+
+    it('displays the managed embargo section', function() {
+      expect(CustomerResourceShowPage.managedEmbargoPeriod).to.equal('6 Months');
+    });
+
+    it('displays the custom embargo section', function() {
+      expect(CustomerResourceShowPage.customEmbargoPeriod).to.equal('9 Weeks');
+    });
+  });
+
+  describe("visiting the customer resource show page without any embargos", function() {
+    beforeEach(function() {
+      return this.visit(`/eholdings/vendors/${pkg.vendor.id}/packages/${pkg.id}/titles/${resource.id}`, () => {
+        expect(CustomerResourceShowPage.$root).to.exist;
+      });
+    });
+
+    it('does not display the managed embargo section', function() {
+      expect(CustomerResourceShowPage.managedEmbargoPeriod).to.equal('');
+    });
+
+    it('does not display the custom embargo section', function() {
+      expect(CustomerResourceShowPage.customEmbargoPeriod).to.equal('');
+    });
+  });
+});

--- a/tests/pages/customer-resource-show.js
+++ b/tests/pages/customer-resource-show.js
@@ -73,5 +73,13 @@ export default {
 
   get isHidden() {
     return $('[data-test-eholdings-customer-resource-show-is-hidden]').length === 1;
+  },
+
+  get managedEmbargoPeriod() {
+    return $('[data-test-eholdings-customer-resource-show-managed-embargo-period]').text()
+  },
+
+  get customEmbargoPeriod() {
+    return $('[data-test-eholdings-customer-resource-show-custom-embargo-period]').text()
   }
 };


### PR DESCRIPTION
Does not include any business logic around when they should be shown. It's simply: if the RM API returns a custom or managed embargo period, show them. If not, nothing is rendered out.

![localhost-3000-eholdings-vendors-1-packages-1-titles-1 iphone 5 2](https://user-images.githubusercontent.com/230597/30231966-098f2ad4-94b3-11e7-8f9e-b0b856736348.png)
