### PR TITLE
Refactor customer resource show route 🦆

### DIFF
--- a/src/components/customer-resource-show.js
+++ b/src/components/customer-resource-show.js
@@ -7,64 +7,67 @@ import KeyValueLabel from './key-value-label';
 import IdentifiersList from './identifiers-list';
 
 export default function CustomerResourceShow({ model, toggleSelected }) {
+  const { record, toggle } = model;
+  const resource = record.content;
+
   return (
     <div data-test-eholdings-customer-resource-show>
       <Paneset>
         <Pane defaultWidth="100%">
-          {model.isLoaded ? (
+          {record.isResolved ? (
             <div>
               <div style={{ margin: '2rem 0' }}>
                 <KeyValueLabel label="Resource">
                   <h1 data-test-eholdings-customer-resource-show-title-name>
-                    {model.titleName}
+                    {resource.titleName}
                   </h1>
                 </KeyValueLabel>
               </div>
 
               <KeyValueLabel label="Publisher">
                 <div data-test-eholdings-customer-resource-show-publisher-name>
-                  {model.publisherName}
+                  {resource.publisherName}
                 </div>
               </KeyValueLabel>
 
               <KeyValueLabel label="Publication Type">
                 <div data-test-eholdings-customer-resource-show-publication-type>
-                  {model.pubType}
+                  {resource.pubType}
                 </div>
               </KeyValueLabel>
 
-              <IdentifiersList data={model.identifiersList} />
+              <IdentifiersList data={resource.identifiersList} />
 
               <KeyValueLabel label="Package">
                 <div data-test-eholdings-customer-resource-show-package-name>
-                  <Link to={`/eholdings/vendors/${model.vendorId}/packages/${model.packageId}`}>{model.packageName}</Link>
+                  <Link to={`/eholdings/vendors/${resource.vendorId}/packages/${resource.packageId}`}>{resource.packageName}</Link>
                 </div>
               </KeyValueLabel>
 
               <KeyValueLabel label="Content Type">
                 <div data-test-eholdings-customer-resource-show-content-type>
-                  {model.contentType}
+                  {resource.contentType}
                 </div>
               </KeyValueLabel>
 
               <KeyValueLabel label="Vendor">
                 <div data-test-eholdings-customer-resource-show-vendor-name>
-                  <Link to={`/eholdings/vendors/${model.vendorId}`}>{model.vendorName}</Link>
+                  <Link to={`/eholdings/vendors/${resource.vendorId}`}>{resource.vendorName}</Link>
                 </div>
               </KeyValueLabel>
 
-              {model.url && (
+              {resource.url && (
                 <KeyValueLabel label="Managed URL">
                   <div data-test-eholdings-customer-resource-show-managed-url>
-                    <Link to={model.url}>{model.url}</Link>
+                    <Link to={resource.url}>{resource.url}</Link>
                   </div>
                 </KeyValueLabel>
               ) }
 
-              {model.subjectsList && model.subjectsList.length > 0 && (
+              {resource.subjectsList && resource.subjectsList.length > 0 && (
                 <KeyValueLabel label="Subjects">
                   <div data-test-eholdings-customer-resource-show-subjects-list>
-                    {model.subjectsList.map((subjectObj) => subjectObj.subject).join('; ')}
+                    {resource.subjectsList.map((subjectObj) => subjectObj.subject).join('; ')}
                   </div>
                 </KeyValueLabel>
               ) }
@@ -73,18 +76,18 @@ export default function CustomerResourceShow({ model, toggleSelected }) {
 
               <KeyValueLabel label="Selected">
                 <div data-test-eholdings-customer-resource-show-selected>
-                  <input type="checkbox" onChange={toggleSelected} disabled={model.isTogglingSelection} checked={model.isSelected} />
-                  {model.isSelected ? 'Yes' : 'No'}
-                  {model.isTogglingSelection ? (
-                    <span data-test-eholdings-customer-resource-show-is-selecting>...</span>) : ('')
-                  }
+                  <input type="checkbox" onChange={toggleSelected} disabled={toggle.isPending} checked={resource.isSelected} />
+                  {resource.isSelected ? 'Yes' : 'No'}
+                  {toggle.isPending && (
+                    <span data-test-eholdings-customer-resource-show-is-selecting>...</span>
+                  )}
                 </div>
               </KeyValueLabel>
 
               <hr/>
 
               <div>
-                <Link to={`/eholdings/titles/${model.titleId}`}>
+                <Link to={`/eholdings/titles/${resource.titleId}`}>
                   View all packages that include this title
                 </Link>
               </div>

--- a/src/redux/customer-resource.js
+++ b/src/redux/customer-resource.js
@@ -1,0 +1,153 @@
+import { combineReducers } from 'redux';
+import { handleActions } from 'redux-actions';
+import { combineEpics } from 'redux-observable';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/from';
+import 'rxjs/add/observable/of';
+import 'rxjs/add/operator/catch';
+import 'rxjs/add/operator/switchMap';
+
+// action types
+const CUSTOMER_RESOURCE_REQUESTED = 'CUSTOMER_RESOURCE_REQUESTED';
+const CUSTOMER_RESOURCE_RESOLVE = 'CUSTOMER_RESOURCE_RESOLVE';
+const CUSTOMER_RESOURCE_REJECT = 'CUSTOMER_RESOURCE_REJECT';
+const CUSTOMER_RESOURCE_TOGGLE_SELECTED = 'CUSTOMER_RESOURCE_TOGGLE_SELECTED';
+const CUSTOMER_RESOURCE_TOGGLE_SELECTED_RESOLVE = 'CUSTOMER_RESOURCE_TOGGLE_SELECTED_RESOLVE';
+const CUSTOMER_RESOURCE_TOGGLE_SELECTED_REJECT = 'CUSTOMER_RESOURCE_TOGGLE_SELECTED_REJECT';
+
+// action creators
+export const requestResource = (vendorId, packageId, titleId) => ({
+  type: CUSTOMER_RESOURCE_REQUESTED,
+  resource: { vendorId, packageId, titleId }
+});
+
+export const toggleSelected = () => ({
+  type: CUSTOMER_RESOURCE_TOGGLE_SELECTED
+});
+
+// customer resource record reducer
+export const recordReducer = handleActions({
+  [CUSTOMER_RESOURCE_REQUESTED]: (state, action) => ({
+    ...state,
+    isPending: true,
+    isResolved: false,
+    isRejected: false,
+    content: {}
+  }),
+  [CUSTOMER_RESOURCE_RESOLVE]: (state, { payload: { customerResourcesList, ...title }}) => ({
+    ...state,
+    isPending: false,
+    isResolved: true,
+    content: {
+      ...title,
+      ...customerResourcesList[0]
+    }
+  }),
+  [CUSTOMER_RESOURCE_REJECT]: (state, { error }) => ({
+    ...state,
+    isPending: false,
+    isRejected: true,
+    error
+  }),
+  [CUSTOMER_RESOURCE_TOGGLE_SELECTED]: (state) => ({
+    ...state,
+    content: {
+      ...state.content,
+      isSelected: !state.content.isSelected
+    }
+  }),
+  [CUSTOMER_RESOURCE_TOGGLE_SELECTED_REJECT]: (state) => ({
+    ...state,
+    content: {
+      ...state.content,
+      isSelected: !state.content.isSelected
+    }
+  })
+}, {
+  isPending: false,
+  isResolved: false,
+  isRejected: false,
+  error: null
+});
+
+// customer resource toggle selected reducer
+const toggleSelectedReducer = handleActions({
+  [CUSTOMER_RESOURCE_TOGGLE_SELECTED]: (state) => ({
+    ...state,
+    isPending: true,
+    isResolved: false,
+    isRejected: false
+  }),
+  [CUSTOMER_RESOURCE_TOGGLE_SELECTED_RESOLVE]: (state) => ({
+    ...state,
+    isPending: false,
+    isResolved: true
+  }),
+  [CUSTOMER_RESOURCE_TOGGLE_SELECTED_REJECT]: (state, { error }) => ({
+    ...state,
+    isPending: false,
+    isRejected: true,
+    error
+  })
+}, {
+  isPending: false,
+  isResolved: false,
+  isRejected: false,
+  error: null
+});
+
+// customer resource epic
+function customerResourceEpic(action$, { getState }) {
+  return action$.ofType(CUSTOMER_RESOURCE_REQUESTED)
+    .switchMap((action) => {
+      let { okapi } = getState();
+      let request = fetchResource(action.resource, { okapi });
+      return Observable.from(request.then((response) => response.json()))
+        .map((payload) => ({ type: CUSTOMER_RESOURCE_RESOLVE, payload }))
+        .catch((error) => Observable.of({ type: CUSTOMER_RESOURCE_REJECT, error }));
+    });
+};
+
+// customer resource toggle selected epic
+function toggleSelectedEpic(action$, { getState }) {
+  return action$.ofType(CUSTOMER_RESOURCE_TOGGLE_SELECTED)
+    .switchMap((action) => {
+      let { okapi, eholdings: { customerResource: { record }} } = getState();
+      let body = JSON.stringify({ isSelected: record.content.isSelected });
+      let request = fetchResource(record.content, { okapi, method: 'PUT', body });
+
+      return Observable.from(request.then((response) => {
+          if (!response.ok) {
+            throw new Error(response.statusText);
+          } else {
+            return response;
+          }
+        }))
+        .map(() => ({ type: CUSTOMER_RESOURCE_TOGGLE_SELECTED_RESOLVE }))
+        .catch((error) => Observable.of({ type: CUSTOMER_RESOURCE_TOGGLE_SELECTED_REJECT, error }));
+    });
+}
+
+// customer resource root reducer
+export const customerResourceReducer = combineReducers({
+  record: recordReducer,
+  toggle: toggleSelectedReducer
+});
+
+// customer resource root epic
+export const customerResourceEpics = combineEpics(
+  customerResourceEpic,
+  toggleSelectedEpic
+);
+
+// helper to fetch a customer resource using the okapi endpoint and headers
+function fetchResource({ vendorId, packageId, titleId }, { okapi, method, body }) {
+  let endpoint = `${okapi.url}/eholdings/vendors/${vendorId}/packages/${packageId}/titles/${titleId}`;
+  let headers = { 'X-Okapi-Tenant': okapi.tenant };
+
+  if (method === 'PUT') {
+    headers['Content-Type'] = 'application/json';
+  }
+
+  return fetch(endpoint, { headers, method, body });
+}

--- a/src/redux/index.js
+++ b/src/redux/index.js
@@ -5,11 +5,17 @@ import {
   searchReducer,
   searchEpic
 } from './search';
+import {
+  customerResourceReducer,
+  customerResourceEpics
+} from './customer-resource';
 
 export const reducer = combineReducers({
-  search: searchReducer
+  search: searchReducer,
+  customerResource: customerResourceReducer
 });
 
 export const epics = combineEpics(
-  searchEpic
+  searchEpic,
+  customerResourceEpics
 );

--- a/src/routes/customer-resource/customer-resource-show.js
+++ b/src/routes/customer-resource/customer-resource-show.js
@@ -2,25 +2,9 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import fetch from 'isomorphic-fetch';
 import { connect } from 'react-redux';
-import { handleActions } from 'redux-actions';
-import  { Observable }  from 'rxjs/Observable';
-import { bindActionCreators } from 'redux'
-
-import 'rxjs/add/observable/from';
-import 'rxjs/add/observable/of';
-import 'rxjs/add/operator/catch';
-import 'rxjs/add/operator/switchMap';
+import { requestResource, toggleSelected } from '../../redux/customer-resource';
 
 import View from '../../components/customer-resource-show';
-
-const ActionTypes = {
-  'CUSTOMER_RESOURCE_SHOW_ERROR': 'CUSTOMER_RESOURCE_SHOW_ERROR',
-  'CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED_REJECT': 'CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED_REJECT',
-  'CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED_RESOLVE': 'CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED_RESOLVE',
-  'CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED': 'CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED',
-  'CUSTOMER_RESOURCE_SHOW_LOADED': 'CUSTOMER_RESOURCE_SHOW_LOADED',
-  'CUSTOMER_RESOURCE_SHOW_LOAD': 'CUSTOMER_RESOURCE_SHOW_LOAD'
-};
 
 class CustomerResourceShowRoute extends Component {
   static propTypes = {
@@ -30,112 +14,16 @@ class CustomerResourceShowRoute extends Component {
         titleId: PropTypes.string.isRequired,
         vendorId: PropTypes.string.isRequired
       }).isRequired
-    }).isRequired
+    }).isRequired,
+    model: PropTypes.object.isRequired
   };
 
-  static contextTypes = {
-    addReducer: PropTypes.func.isRequired,
-    addEpic: PropTypes.func.isRequired
-  }
-
-
   componentWillMount() {
-    let { okapi } = this.props;
-
-    let headers = {
-      'Content-Type': 'application/json',
-      'X-Okapi-Tenant': okapi.tenant
-    };
-
-
-    const ToggleSelectionEpic = (action$, { getState }) => (
-      action$.ofType(ActionTypes.CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED)
-        .switchMap((action) => {
-          let { endpoint, isSelected } = getState().customerResourceShow;
-          let body = JSON.stringify({isSelected: isSelected});
-          let request = fetch(endpoint, { headers, method: 'PUT', body });
-
-          return Observable.from(request.then(
-            (response) => {
-              if(!response.ok) {
-                throw Error(response.statusText)
-              }
-              return response;
-            }
-          ))
-            .map(() => ({ type: ActionTypes.CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED_RESOLVE }))
-            .catch((error) => Observable.of({ type: ActionTypes.CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED_REJECT, error }));
-        })
-    );
-
-
-
-    const ResourceLoadedEpic = (action$, { getState }) => (
-      action$.ofType(ActionTypes.CUSTOMER_RESOURCE_SHOW_LOAD)
-        .switchMap((action) => {
-          let { endpoint } = getState().customerResourceShow;
-          let request = fetch(endpoint, { headers });
-
-          return Observable.from(request.then((response) => response.json()))
-            .map((json) => ({ type: ActionTypes.CUSTOMER_RESOURCE_SHOW_LOADED, payload: json }))
-            .catch((error) => Observable.of({ type: ActionTypes.CUSTOMER_RESOURCE_SHOW_ERROR, error }));
-        })
-    );
-
-    this.context.addEpic('customerResourceToggleSelected', ToggleSelectionEpic);
-    this.context.addEpic('customerResourceShowLoad', ResourceLoadedEpic);
-
-    this.context.addReducer('customerResourceShow', handleActions({
-      [ActionTypes.CUSTOMER_RESOURCE_SHOW_LOAD]: (state, action) => {
-        let { vendorId, packageId, titleId } = action.params;
-        let endpoint = `${okapi.url}/eholdings/vendors/${vendorId}/packages/${packageId}/titles/${titleId}`;
-        return {...state, endpoint};
-      },
-      [ActionTypes.CUSTOMER_RESOURCE_SHOW_LOADED]: (state, action) => {
-        let { customerResourcesList, ...title } = action.payload;
-        let resource = customerResourcesList[0];
-
-        return {
-          ...state,
-          isLoaded: true,
-          isErrored: false,
-          ...title,
-          ...resource
-        };
-      },
-      [ActionTypes.CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED]: (state, action) => {
-        return {
-          ...state,
-          isSelected: !state.isSelected,
-          isTogglingSelection: true
-        };
-      },
-      [ActionTypes.CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED_RESOLVE]: (state, action) => {
-        return {
-          ...state,
-          isTogglingSelection: false
-        };
-      },
-      [ActionTypes.CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED_REJECT]: (state, action) => {
-        return {
-          ...state,
-          isTogglingSelection: false,
-          isSelected: !state.isSelected
-        };
-      },
-      [ActionTypes.CUSTOMER_RESOURCE_SHOW_ERROR]: (state, action) => {
-        return {
-          ...state,
-          toggleSelectionError: action.error
-        };
-      }
-    }, { isLoaded: false, isErrored: false }));
-
-    this.props.loadRecord(this.props.match.params);
+    let { vendorId, packageId, titleId } = this.props.match.params;
+    this.props.requestResource(vendorId, packageId, titleId);
   }
 
   render() {
-    let { vendorId, packageId, titleId } = this.props.match.params;
     return (
       <View
         model={this.props.model}
@@ -145,22 +33,11 @@ class CustomerResourceShowRoute extends Component {
   }
 }
 
-function mapStateToProps(state) {
-  let { okapi, customerResourceShow } = state;
-  return {
-    okapi,
-    model: customerResourceShow || {
-      isLoaded: false,
-      isErrored: false
-    }
-  };
-}
-
-const loadRecord = (params) => ({
-  type: 'CUSTOMER_RESOURCE_SHOW_LOAD', params
-});
-const toggleSelected = (event) => ({
-  type: 'CUSTOMER_RESOURCE_SHOW_TOGGLE_SELECTED'
-});
-
-export default connect(mapStateToProps, { loadRecord, toggleSelected })(CustomerResourceShowRoute);
+export default connect(
+  ({ eholdings: { customerResource }}) => ({
+    model: customerResource
+  }), {
+    requestResource,
+    toggleSelected
+  }
+)(CustomerResourceShowRoute);


### PR DESCRIPTION
This pulls the original reducer and epics out into their own "duck" file to be used with the `eholdings` root reducer / epic, and splits the customer resource model's state into `record` and `toggle` pieces to reflect the two different operations.

This is related to stripping `stripes-connect` from the app, as all other routes will have their own reducers and epics defined in the `redux` directory as well.