### PR TITLE
Ensure reliable click events in customer resource test

### DIFF
--- a/tests/customer-resource-show-test.js
+++ b/tests/customer-resource-show-test.js
@@ -77,7 +77,21 @@ describeApplication('CustomerResourceShow', function() {
 
     describe("selecting a package title to add to my holdings", function() {
       beforeEach(function() {
-        ResourcePage.toggleIsSelected();
+        /*
+         * The expectations in the convergent `it` blocks
+         * get run once every 10ms.  We were seeing test flakiness
+         * when a toggle action dispatched and resolved before an
+         * expectation had the chance to run.  We sidestep this by
+         * temporarily increasing the mirage server's response time
+         * to 50ms.
+         * TODO: control timing directly with Mirage
+         */
+        this.server.timing = 50;
+        return ResourcePage.toggleIsSelected();
+      });
+
+      afterEach(function() {
+        this.server.timing = 0;
       });
 
       it('reflects the desired state (YES)', function() {
@@ -118,3 +132,4 @@ describeApplication('CustomerResourceShow', function() {
     });
   });
 });
+0

--- a/tests/pages/customer-resource-show.js
+++ b/tests/pages/customer-resource-show.js
@@ -1,4 +1,6 @@
 import $ from 'jquery';
+import { convergeOn } from '../it-will';
+import { expect } from 'chai';
 
 export default {
   get $root() {
@@ -46,7 +48,15 @@ export default {
   },
 
   toggleIsSelected() {
-    $('[data-test-eholdings-customer-resource-show-selected] input').click();
+    /*
+     * We don't want to click the element before it exists.  This should
+     * probably become a generic 'click' helper once we have more usage.
+     */
+    return convergeOn(() => {
+      expect($('[data-test-eholdings-customer-resource-show-selected]')).to.exist;
+    }).then(() => (
+      $('[data-test-eholdings-customer-resource-show-selected] input').click()
+    ));
   },
 
   get isSelecting() {


### PR DESCRIPTION
We were seeing flakiness around the tests related to selecting/deselcting packages.
These enhancements ensure the existence of an element to be clicked before performing the click.
We also temporarily increase the mirage server timing to account for requests completing before the convergent `it` gets a chance to assert anything about in-flight requests.