### PR TITLE
Refactor search state to use promise-like booleans

### DIFF
--- a/src/redux/search.js
+++ b/src/redux/search.js
@@ -10,7 +10,7 @@ import merge from 'lodash/merge';
 // action types
 const EHOLDINGS_SEARCH = 'EHOLDINGS_SEARCH';
 const EHOLDINGS_SEARCH_RESOLVE = 'EHOLDINGS_SEARCH_RESOLVE';
-const EHOLDINGS_SEARCH_ERRORED = 'EHOLDINGS_SEARCH_ERRORED';
+const EHOLDINGS_SEARCH_REJECT = 'EHOLDINGS_SEARCH_REJECT';
 
 // action creators
 export const searchHoldings = (searchType, query, options) => ({
@@ -23,9 +23,10 @@ export const searchHoldings = (searchType, query, options) => ({
 // initial state for each search type
 const initialSearchState = {
   query: {},
-  isLoading: false,
-  isErrored: false,
-  records: [],
+  isPending: false,
+  isResolved: false,
+  isRejected: false,
+  content: [],
   error: null
 };
 
@@ -36,8 +37,10 @@ export const searchReducer = handleActions({
     [action.searchType]: {
       ...state[action.searchType],
       query: action.query,
-      isLoading: true,
-      isErrored: false,
+      isPending: true,
+      isResolved: false,
+      isRejected: false,
+      content: [],
       error: null
     }
   }),
@@ -45,16 +48,17 @@ export const searchReducer = handleActions({
     ...state,
     [action.searchType]: {
       ...state[action.searchType],
-      isLoading: false,
-      records: action.payload
+      isPending: false,
+      isResolved: true,
+      content: action.payload
     }
   }),
-  [EHOLDINGS_SEARCH_ERRORED]: (state, action) => ({
+  [EHOLDINGS_SEARCH_REJECT]: (state, action) => ({
     ...state,
     [action.searchType]: {
       ...state[action.searchType],
-      isLoading: false,
-      isErrored: true,
+      isPending: false,
+      isRejected: true,
       error: action.error
     }
   })
@@ -78,6 +82,6 @@ export function searchEpic(action$, { getState }) {
 
       return Observable.from(request.then((res) => res.json())).pluck(recordsKey)
         .map((payload) => ({ type: EHOLDINGS_SEARCH_RESOLVE, searchType, payload }))
-        .catch((error) => Observable.of({ type: EHOLDINGS_SEARCH_ERRORED, searchType, error }));
+        .catch((error) => Observable.of({ type: EHOLDINGS_SEARCH_REJECT, searchType, error }));
     });
 }

--- a/src/routes/package/package-search-results.js
+++ b/src/routes/package/package-search-results.js
@@ -7,22 +7,23 @@ import PackageListItem from '../../components/package-list-item';
 
 function PackageSearchResults({
   query: { search },
-  isLoading,
-  isErrored,
-  records,
+  isPending,
+  isResolved,
+  isRejected,
+  content,
   error
 }) {
-  return isLoading ? (
+  return isPending ? (
     <p>...loading</p>
-  ) : isErrored ? (
+  ) : isRejected ? (
     <p data-test-package-search-error-message>{error}</p>
-  ) : !records.length && search ? (
+  ) : isResolved && !content.length ? (
     <p data-test-package-search-no-results>
       No packages found for <strong>{`"${search}"`}</strong>.
     </p>
   ) : (
     <List data-test-package-search-results-list>
-      {records.map((pkg) => (
+      {content.map((pkg) => (
         <PackageListItem
             key={pkg.packageId}
             link={`/eholdings/vendors/${pkg.vendorId}/packages/${pkg.packageId}`}
@@ -36,9 +37,10 @@ PackageSearchResults.propTypes = {
   query: PropTypes.shape({
     search: PropTypes.string
   }).isRequired,
-  isLoading: PropTypes.bool.isRequired,
-  isErrored: PropTypes.bool.isRequired,
-  records: PropTypes.array.isRequired,
+  isPending: PropTypes.bool.isRequired,
+  isResolved: PropTypes.bool.isRequired,
+  isRejected: PropTypes.bool.isRequired,
+  content: PropTypes.array.isRequired,
   error: PropTypes.object
 };
 

--- a/src/routes/title/title-search-results.js
+++ b/src/routes/title/title-search-results.js
@@ -7,22 +7,23 @@ import TitleListItem from '../../components/title-list-item';
 
 function TitleSearchResults({
   query: { search },
-  isLoading,
-  isErrored,
-  records,
+  isPending,
+  isResolved,
+  isRejected,
+  content,
   error
 }) {
-  return isLoading ? (
+  return isPending ? (
     <p>...loading</p>
-  ) : isErrored ? (
+  ) : isRejected ? (
     <p data-test-title-search-error-message>{error}</p>
-  ) : !records.length && search ? (
+  ) : isResolved && !content.length ? (
     <p data-test-title-search-no-results>
       No titles found for <strong>{`"${search}"`}</strong>.
     </p>
   ) : (
     <List data-test-title-search-results-list>
-      {records.map((title) => (
+      {content.map((title) => (
         <TitleListItem
             key={title.titleId}
             link={`/eholdings/titles/${title.titleId}`}
@@ -36,9 +37,10 @@ TitleSearchResults.propTypes = {
   query: PropTypes.shape({
     search: PropTypes.string
   }).isRequired,
-  isLoading: PropTypes.bool.isRequired,
-  isErrored: PropTypes.bool.isRequired,
-  records: PropTypes.array.isRequired,
+  isPending: PropTypes.bool.isRequired,
+  isResolved: PropTypes.bool.isRequired,
+  isRejected: PropTypes.bool.isRequired,
+  content: PropTypes.array.isRequired,
   error: PropTypes.object
 };
 

--- a/src/routes/vendor/vendor-search-results.js
+++ b/src/routes/vendor/vendor-search-results.js
@@ -7,22 +7,23 @@ import VendorListItem from '../../components/vendor-list-item';
 
 function VendorSearchResultsRoute({
   query: { search },
-  isLoading,
-  isErrored,
-  records,
+  isPending,
+  isResolved,
+  isRejected,
+  content,
   error
 }) {
-  return isLoading ? (
+  return isPending ? (
     <p>...loading</p>
-  ) : isErrored ? (
+  ) : isRejected ? (
     <p data-test-vendor-search-error>{error}</p>
-  ) : !records.length && search ? (
+  ) : isResolved && !content.length ? (
     <p data-test-vendor-search-no-results>
       No vendors found for <strong>{`"${search}"`}</strong>.
     </p>
   ) : (
     <List data-test-vendor-search-results-list>
-      {records.map((vendor) => (
+      {content.map((vendor) => (
         <VendorListItem
             key={vendor.vendorId}
             item={vendor}
@@ -36,9 +37,10 @@ VendorSearchResultsRoute.propTypes = {
   query: PropTypes.shape({
     search: PropTypes.string
   }).isRequired,
-  isLoading: PropTypes.bool.isRequired,
-  isErrored: PropTypes.bool.isRequired,
-  records: PropTypes.array.isRequired,
+  isPending: PropTypes.bool.isRequired,
+  isResolved: PropTypes.bool.isRequired,
+  isRejected: PropTypes.bool.isRequired,
+  content: PropTypes.array.isRequired,
   error: PropTypes.object
 };
 


### PR DESCRIPTION
Renamed the following search state properties and added `isResolved`

```
isLoading -> isPending
isErrored -> isRejected
records -> content
```