### PR TITLE
Enforce ESLint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   root: true,
+  parser: 'babel-eslint',
   parserOptions: {
     ecmaVersion: 2017,
     sourceType: 'module',

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
 cache:
   yarn: true
 script:
+  - yarn lint
   - yarn test -- --single-run
 before_deploy:
   - environment=production yarn build

--- a/demo/stripes.js
+++ b/demo/stripes.js
@@ -48,6 +48,12 @@ commander
     if (options.cache) config.plugins.push(cachePlugin);
     if (options.devtool) config.devtool = options.devtool;
 
+    // Show eslint failures at runtime
+    config.module.rules.push({
+      test: /src\/.*\.js$/,
+      loader: 'eslint-loader'
+    });
+
     const compiler = webpack(mirage(svgloader(config)));
 
     const port = options.port || process.env.STRIPES_PORT || 3000;

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
     "postinstall": "bin/link-self",
     "start": "node demo/stripes.js dev demo/stripes.config.js",
     "build": "node demo/stripes.js build demo/stripes.config.js dist",
-    "test": "karma start"
+    "test": "karma start",
+    "lint": "eslint src"
   },
   "devDependencies": {
     "@folio/stripes-core": "thefrontside/stripes-core#master",
     "babel-core": "^6.25.0",
+    "babel-eslint": "^7.2.3",
     "babel-loader": "^7.1.1",
     "babel-preset-env": "^1.6.0",
     "babel-preset-react": "^6.24.1",

--- a/src/components/customer-resource-show.js
+++ b/src/components/customer-resource-show.js
@@ -111,5 +111,6 @@ export default function CustomerResourceShow({ model, toggleSelected }) {
 
 CustomerResourceShow.propTypes = {
   model: PropTypes.object,
-  saveSelected: PropTypes.func
+  saveSelected: PropTypes.func,
+  toggleSelected: PropTypes.func
 };

--- a/src/components/list/list.js
+++ b/src/components/list/list.js
@@ -1,6 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import styles from './list.css';
 
 export default function List({ className, ...props }) {
   return <ul className={[styles['list'], className].join(' ')} {...props}/>;
+}
+
+List.propTypes = {
+  className: PropTypes.string
 }

--- a/src/components/vendor-show.js
+++ b/src/components/vendor-show.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Link } from 'react-router-dom';
 import Paneset from '@folio/stripes-components/lib/Paneset';
 import Pane from '@folio/stripes-components/lib/Pane';
 import KeyValueLabel from './key-value-label';

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ export default class EHoldings extends Component {
       path: PropTypes.string.isRequired
     }).isRequired,
     stripes: PropTypes.shape({
+      connect: PropTypes.func.isRequired,
       intl: PropTypes.object.isRequired
     }).isRequired
   };

--- a/src/redux/customer-resource.js
+++ b/src/redux/customer-resource.js
@@ -27,7 +27,7 @@ export const toggleSelected = () => ({
 
 // customer resource record reducer
 export const recordReducer = handleActions({
-  [CUSTOMER_RESOURCE_REQUESTED]: (state, action) => ({
+  [CUSTOMER_RESOURCE_REQUESTED]: (state) => ({
     ...state,
     isPending: true,
     isResolved: false,
@@ -106,12 +106,12 @@ function customerResourceEpic(action$, { getState }) {
         .map((payload) => ({ type: CUSTOMER_RESOURCE_RESOLVE, payload }))
         .catch((error) => Observable.of({ type: CUSTOMER_RESOURCE_REJECT, error }));
     });
-};
+}
 
 // customer resource toggle selected epic
 function toggleSelectedEpic(action$, { getState }) {
   return action$.ofType(CUSTOMER_RESOURCE_TOGGLE_SELECTED)
-    .switchMap((action) => {
+    .switchMap(() => {
       let { okapi, eholdings: { customerResource: { record }} } = getState();
       let body = JSON.stringify({ isSelected: record.content.isSelected });
       let request = fetchResource(record.content, { okapi, method: 'PUT', body });

--- a/src/redux/search.js
+++ b/src/redux/search.js
@@ -5,6 +5,7 @@ import 'rxjs/add/observable/from';
 import 'rxjs/add/operator/switchMap';
 import 'rxjs/add/operator/pluck';
 import 'rxjs/add/operator/catch';
+import merge from 'lodash/merge';
 
 // action types
 const EHOLDINGS_SEARCH = 'EHOLDINGS_SEARCH';
@@ -58,9 +59,9 @@ export const searchReducer = handleActions({
     }
   })
 }, {
-  vendors: _.merge({}, initialSearchState),
-  packages: _.merge({}, initialSearchState),
-  titles: _.merge({}, initialSearchState)
+  vendors: merge({}, initialSearchState),
+  packages: merge({}, initialSearchState),
+  titles: merge({}, initialSearchState)
 });
 
 // search epic
@@ -71,8 +72,8 @@ export function searchEpic(action$, { getState }) {
       const { searchType, query, options } = action;
       const { endpoint, defaults, recordsKey = searchType } = options;
 
-      const searchQuery = { ...query, ...defaults };
-      const url = `${okapi.url}/${endpoint}?${queryString.stringify(query)}`;
+      const searchQuery = { ...defaults, ...query };
+      const url = `${okapi.url}/${endpoint}?${queryString.stringify(searchQuery)}`;
       const request = fetch(url, { headers: { 'X-Okapi-Tenant': okapi.tenant }});
 
       return Observable.from(request.then((res) => res.json())).pluck(recordsKey)

--- a/src/routes/customer-resource/customer-resource-show.js
+++ b/src/routes/customer-resource/customer-resource-show.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import fetch from 'isomorphic-fetch';
 import { connect } from 'react-redux';
 import { requestResource, toggleSelected } from '../../redux/customer-resource';
 
@@ -15,7 +14,9 @@ class CustomerResourceShowRoute extends Component {
         vendorId: PropTypes.string.isRequired
       }).isRequired
     }).isRequired,
-    model: PropTypes.object.isRequired
+    model: PropTypes.object.isRequired,
+    requestResource: PropTypes.func.isRequired,
+    toggleSelected: PropTypes.func.isRequired
   };
 
   componentWillMount() {

--- a/src/routes/package/package-search-results.js
+++ b/src/routes/package/package-search-results.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 

--- a/src/routes/package/package-show.js
+++ b/src/routes/package/package-show.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import fetch from 'isomorphic-fetch';
 
 import View from '../../components/package-show';
 
@@ -62,7 +61,7 @@ export default class PackageShowRoute extends Component {
   getPackageTitles() {
     const {
       resources: { showPackageTitles },
-      match: { params: { vendorId, packageId } }
+      match: { params: { packageId } }
     } = this.props;
 
     if (!showPackageTitles) {

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -55,7 +55,8 @@ class SearchRoute extends Component {
       packages: PropTypes.object.isRequired,
       titles: PropTypes.object.isRequired
     }).isRequired,
-    searchHoldings: PropTypes.func.isRequired
+    searchHoldings: PropTypes.func.isRequired,
+    children: PropTypes.node.isRequired
   };
 
   componentWillMount() {

--- a/src/routes/title/title-search-results.js
+++ b/src/routes/title/title-search-results.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 

--- a/src/routes/title/title-show.js
+++ b/src/routes/title/title-show.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import fetch from 'isomorphic-fetch';
 
 import View from '../../components/title-show';
 

--- a/src/routes/vendor/vendor-search-results.js
+++ b/src/routes/vendor/vendor-search-results.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 

--- a/src/routes/vendor/vendor-show.js
+++ b/src/routes/vendor/vendor-show.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import fetch from 'isomorphic-fetch';
 
 import View from '../../components/vendor-show';
 


### PR DESCRIPTION
When running the dev server, ESLint will emit errors:
![screen shot 2017-09-11 at 4 48 49 pm](https://user-images.githubusercontent.com/230597/30299174-1edb3bae-9714-11e7-8bf0-61ecdb9ef6a6.png)

`yarn test` will not run `ESLint` assertions, but `yarn lint` will.

Travis CI builds will fail with ESLint errors: https://travis-ci.org/thefrontside/ui-eholdings/builds/274360479

Only pays attention to the `src` directory for now. We should gradually transition over to using the same ruleset as `stripes-core`.