### PR TITLE
Make eslint-loader quieter

### DIFF
--- a/demo/stripes.js
+++ b/demo/stripes.js
@@ -51,7 +51,10 @@ commander
     // Show eslint failures at runtime
     config.module.rules.push({
       test: /src\/.*\.js$/,
-      loader: 'eslint-loader'
+      loader: 'eslint-loader',
+      options: {
+        emitWarning: true
+      }
     });
 
     const compiler = webpack(mirage(svgloader(config)));


### PR DESCRIPTION
ESLint validation problems will now just warn to the console, instead of throwing an error in an overlay in the browser.