### PR TITLE
Make routes nestable.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Route, Switch, Redirect } from 'react-router-dom';
+import { Route, Switch, Redirect } from './router';
 
 import { reducer, epics } from './redux';
 
@@ -58,13 +58,11 @@ export default class EHoldings extends Component {
 
     return(
       <Switch>
-        <Route path={`${rootPath}/search/:searchType(vendors|packages|titles)`} render={(props) => (
-          <SearchRoute {...props}>
-            <Route path={`${rootPath}/search/vendors`} exact component={VendorSearchResultsRoute}/>
-            <Route path={`${rootPath}/search/packages`} exact component={PackageSearchResultsRoute}/>
-            <Route path={`${rootPath}/search/titles`} exact component={TitleSearchResultsRoute}/>
-          </SearchRoute>
-        )}/>
+        <Route path={`${rootPath}/search/:searchType(vendors|packages|titles)`} component={SearchRoute}>
+          <Route path={`${rootPath}/search/vendors`} exact component={VendorSearchResultsRoute}/>
+          <Route path={`${rootPath}/search/packages`} exact component={PackageSearchResultsRoute}/>
+          <Route path={`${rootPath}/search/titles`} exact component={TitleSearchResultsRoute}/>
+        </Route>
 
         <Route path={`${rootPath}/vendors/:vendorId`} exact component={this.VendorShow}/>
         <Route path={`${rootPath}/vendors/:vendorId/packages/:packageId`} exact component={this.PackageShow}/>

--- a/src/router.js
+++ b/src/router.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Route as RouterRoute } from 'react-router-dom';
+
+export { Switch, Redirect } from 'react-router-dom';
+
+/**
+ * Pass the children of a Route to the component that is responsible for rendering it.
+ * This allows us to have a single route hierarchy, where the routing
+ * components are responsible for marshalling data, and providing high
+ * level layout:
+ *
+ *   // routes.js
+ *   <Route component={ParentRoute}>
+ *     <Route component={ChildRoute}/>
+ *   </Route>
+ *
+ *   //parent-route.js
+ *   import Layout from './layout';
+ *   export default class ParentRoute extends Component {
+ *     render() {
+ *       return (<Layout>{children}</Layout>);
+ *     }
+ *   }
+ *
+ * will take all of the children of the top level `Route` component,
+ * and pass them as the children of the `ParentRoute` component.
+ */
+export function Route({component: Component, children, ...props}) {
+  if (Component) {
+    return (
+      <RouterRoute {...props} render={(props) => (<Component {...props}>{children}</Component>)} />
+    );
+  } else {
+    return (<RouterRoute {...props}>{children}</RouterRoute>);
+  }
+}
+
+Route.propTypes = {
+  component: PropTypes.func,
+  children: PropTypes.node
+};


### PR DESCRIPTION
In order to have a single manifest of routes at the top of our route hiearchy, we need the ability to nest route components into other route components. However, this requires using a closure in the `render` property with vanilla React Router v4.

This becomes unwieldy once you have have routes nested within other routes, especially when you want to have a single, application route sitting at the top of your routes so that your entire routing structure sits inside a closure (ick!)

This re-maps the children of a route over to the component that the route is rendering, letting us keep our routes nice and flat, and using simple JSX without closure properties.