### PR TITLE
Opt in to Mirage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@
 * `yarn start`
 * Visit your app at [http://localhost:8080](http://localhost:8080).
 
+By default, this will use the backend OKAPI cluster at
+https://okapi.frontside.io However, if you want to run the application
+against the mirage server contained within the browser, you can turn
+it on with the `--mirage` option:
+
+* `yarn start --mirage`
+
 ## Running Tests
 
 * `yarn test` (uses Karma and Mocha to test the application)

--- a/demo/stripes.js
+++ b/demo/stripes.js
@@ -30,6 +30,7 @@ commander
   .option('--host [host]', 'Host')
   .option('--cache', 'Use HardSourceWebpackPlugin cache')
   .option('--devtool [devtool]', 'Use another value for devtool instead of "inline-source-map"')
+  .option('--mirage', 'Use the mirage server to simulate the backend')
   .arguments('<config>')
   .description('Launch a webpack-dev-server')
   .action(function (loaderConfigFile, options) {
@@ -57,7 +58,7 @@ commander
       }
     });
 
-    const compiler = webpack(mirage(svgloader(config)));
+    const compiler = webpack(mirage(svgloader(config), options.mirage));
 
     const port = options.port || process.env.STRIPES_PORT || 3000;
     const host = options.host || process.env.STRIPES_HOST || 'localhost';
@@ -114,10 +115,15 @@ if (!process.argv.slice(2).length) {
   commander.outputHelp();
 }
 
-function mirage(config) {
-  return Object.assign({}, config, {
-    entry: ['./demo/boot-mirage'].concat(config.entry)
-  });
+function mirage(config, enabled = false) {
+  if (enabled) {
+    console.info('Using Mirage Server');
+    return Object.assign({}, config, {
+      entry: ['./demo/boot-mirage'].concat(config.entry)
+    });
+  } else {
+    return config;
+  }
 }
 
 function svgloader(config) {


### PR DESCRIPTION
Up until this point, we've been using Mirage as the default backend for running our development server. This has served us well as we built up the API, but nowadays, we will go large spans of time where we aren't changing the backend at all, but only the UI that is built on top of it.

It makes sense then to make running against the (somewhat) stable backend as the default. However, if you want to enable Mirage then you can do so by setting the `MIRAGE` environment variable