### PR TITLE
Fix convergent negation test

### DIFF
--- a/tests/customer-resource-show-embargo-test.js
+++ b/tests/customer-resource-show-embargo-test.js
@@ -52,11 +52,11 @@ describeApplication('CustomerResourceShowEmbargos', function() {
       });
     });
 
-    it('does not display the managed embargo section', function() {
+    it.still('does not display the managed embargo section', function() {
       expect(CustomerResourceShowPage.managedEmbargoPeriod).to.equal('');
     });
 
-    it('does not display the custom embargo section', function() {
+    it.still('does not display the custom embargo section', function() {
       expect(CustomerResourceShowPage.customEmbargoPeriod).to.equal('');
     });
   });

--- a/tests/it-will.js
+++ b/tests/it-will.js
@@ -36,7 +36,7 @@ function itOnly(name, assertion) {
     it.immediately.only(name, _convergeOn(assertion));
 }
 
-function itStill(name, assertion, time = 200) {
+function itStill(name, assertion, time = 50) {
   return !assertion ? it.immediately(name) :
     it.immediately(name, _convergeOn(assertion, true, time));
 }

--- a/tests/package-show-custom-coverage-test.js
+++ b/tests/package-show-custom-coverage-test.js
@@ -51,7 +51,7 @@ describeApplication('PackageShowCustomCoverage', function() {
       });
     });
 
-    it('does not display the custom coverage section', function() {
+    it.still('does not display the custom coverage section', function() {
       expect(PackageShowPage.customCoverage).to.equal('');
     });
   });


### PR DESCRIPTION
This fixes tests similar to this: 

```js
it('does not display some thing', function() {
  expect(PageObject.someValue).to.equal('');
});
```

With convergent assertions, these will still pass because `someValue` hasn't had a chance to update to the side effects from `beforeEach` (i.e. loading a record).

To see this, simply move one of these negation tests to someplace it should fail, and **it will still pass**.

We could assert that a record has been loaded before our assertions are run, however sometimes the DOM may be milliseconds behind in rendering and the convergent assertion will still pass.

Instead we should use `it.still` which assures that the assertion is true for a given amount of time:

```js
it.still('does not display some thing', function() {
  expect(PageObject.someValue).to.equal('');
});
```

However, by default, the timeout is 200ms. And so for each `it.still`, our tests would become 200ms slower.

The most optimal solution would be to get mocha to run our tests in parallel, after side effects. This way only an entire suit would be delayed by 200ms no matter how many `it.still`s were used inside.