### PR TITLE
Use styles that are closer to stripes defaults

### DIFF
--- a/src/components/search-form/search-form.css
+++ b/src/components/search-form/search-form.css
@@ -1,4 +1,7 @@
+@import '@folio/stripes-core/src/components/variables';
+
 .search-form-container {
+  margin: 1em 0 0.5em 0;
   width: 100%;
 }
 
@@ -8,24 +11,45 @@
 
   & a {
     display: inline-block;
-    border: solid #ccc;
+    border: 1px solid var(--primary);
     border-width: 1px 1px 1px 0;
-    padding: 0.4em 0.6em;
+    padding: 0.36em 0.57em;
     text-decoration: none;
     line-height: 1;
 
     &:first-child {
       border-left-width: 1px;
-      border-radius: 0.3em 0 0 0.3em;
+      border-radius: 0.4em 0 0 0.4em;
     }
 
     &:last-child {
-      border-radius: 0 0.3em 0.3em 0;
+      border-radius: 0 0.4em 0.4em 0;
     }
 
     &.is-active {
-      background-color: #eee;
+      background-color: var(--primary);
+      color: #fff;
     }
+  }
+}
+
+.search-input {
+  height: var(--controlHeight);
+  min-height: var(--controlHeight);
+  margin-bottom: var(--controlMarginBottom);
+  padding: 4px;
+  border: 1px solid var(--inputBorderColor);
+}
+
+.search-submit {
+  margin-left: 0.5em;
+  background-color: var(--primary);
+  border: 1px solid var(--primary);
+  border-radius: 0.4em;
+  color: #fff;
+
+  &:hover{
+    background-color: color(var(--primary) shade(8%));
   }
 }
 

--- a/src/components/search-form/search-form.js
+++ b/src/components/search-form/search-form.js
@@ -54,6 +54,7 @@ export default class SearchForm extends Component {
         </div>
         <form onSubmit={this.handleSearchSubmit}>
           <input
+              className={styles['search-input']}
               type="search"
               name="search"
               value={searchString}
@@ -61,6 +62,7 @@ export default class SearchForm extends Component {
               onChange={this.handleChangeSearch}
               data-test-search-field />
           <button
+              className={styles['search-submit']}
               type="submit"
               disabled={!searchString}
               data-test-search-submit>


### PR DESCRIPTION
Imports some sass variables from `stripes-core`.

Long-term: should use some `stripes-components` instead of implementing our own.

![localhost-3000-eholdings-search-vendors](https://user-images.githubusercontent.com/230597/30443783-60b88480-9946-11e7-8be2-edf9a73b4557.png)
