### PR TITLE
Fix some package / package-title attribute displays

### DIFF
--- a/src/components/customer-resource-show.js
+++ b/src/components/customer-resource-show.js
@@ -46,11 +46,13 @@ export default function CustomerResourceShow({ model, toggleSelected }) {
                 </div>
               </KeyValueLabel>
 
-              <KeyValueLabel label="Content Type">
-                <div data-test-eholdings-customer-resource-show-content-type>
-                  {resource.contentType}
-                </div>
-              </KeyValueLabel>
+              {resource.contentType && (
+                <KeyValueLabel label="Content Type">
+                  <div data-test-eholdings-customer-resource-show-content-type>
+                    {resource.contentType}
+                  </div>
+                </KeyValueLabel>
+              ) }
 
               <KeyValueLabel label="Vendor">
                 <div data-test-eholdings-customer-resource-show-vendor-name>

--- a/src/components/identifiers-list.js
+++ b/src/components/identifiers-list.js
@@ -27,11 +27,18 @@ export default function IdentifiersList({ data }) {
     7: 'Invalid'
   };
 
+  let typesCount = Object.keys(types).length;
+  let subtypesCount = Object.keys(subtypes).length;
+
   // turn type and subtype ids into strings
   let identifiersWithCompoundTypes = data.map((identifier) => {
     let compoundType = types[identifier.type];
 
-    if(identifier.subtype > 0) {
+    if(identifier.type >= typesCount) {
+      compoundType = 'Unknown Identifier';
+    }
+
+    if(identifier.subtype > 0 && identifier.subtype < subtypesCount) {
       compoundType = `${compoundType} (${subtypes[identifier.subtype]})`;
     }
 

--- a/src/components/package-show.js
+++ b/src/components/package-show.js
@@ -38,11 +38,13 @@ export default function PackageShow({ vendorPackage, packageTitles }, { intl }) 
                 </div>
               </KeyValueLabel>
 
-              <KeyValueLabel label="Content Type">
-                <div data-test-eholdings-package-details-content-type>
-                  {vendorPackage.contentType}
-                </div>
-              </KeyValueLabel>
+              {vendorPackage.contentType && (
+                <KeyValueLabel label="Content Type">
+                  <div data-test-eholdings-package-details-content-type>
+                    {vendorPackage.contentType}
+                  </div>
+                </KeyValueLabel>
+              ) }
 
               <KeyValueLabel label="Titles Selected">
                 <div data-test-eholdings-package-details-titles-selected>


### PR DESCRIPTION
Solves two problems shown in the screenshot below:

- Don't show content type if it's not returned from RM API.
- If a type or subtype of an identifier is outside of the bounds of what we know, call it an "Unknown Identifier." We were being returned ids not defined in the RM API docs https://developer.ebsco.com/rmapireference#identifier. It would be much better to receive the string describing the identifier from the RM API, instead of having to manually map ids.

![screen shot 2017-09-14 at 1 19 03 pm](https://user-images.githubusercontent.com/230597/30446776-be25f6d0-994f-11e7-93ea-97cb2910f04b.png)
