### PR TITLE
Ignore identifiers that aren’t ISSN or ISBN

### DIFF
--- a/src/components/identifiers-list.js
+++ b/src/components/identifiers-list.js
@@ -5,40 +5,25 @@ import KeyValueLabel from './key-value-label';
 export default function IdentifiersList({ data }) {
   let types = {
     0: 'ISSN',
-    1: 'ISBN',
-    2: 'TSDID',
-    3: 'SPID',
-    4: 'EjsJournaID',
-    5: 'NewsbankID',
-    6: 'ZDBID',
-    7: 'EPBookID',
-    8: 'Mid',
-    9: 'BHM'
+    1: 'ISBN'
   };
 
   let subtypes = {
     0: 'Empty',
     1: 'Print',
-    2: 'Online',
-    3: 'Preceding',
-    4: 'Succeeding',
-    5: 'Regional',
-    6: 'Linking',
-    7: 'Invalid'
+    2: 'Online'
   };
 
-  let typesCount = Object.keys(types).length;
-  let subtypesCount = Object.keys(subtypes).length;
+  // get rid of identifiers we received that aren't ISSN or ISBN
+  let filteredData = data.filter((identifier) => {
+    return (identifier.type === 0 ||  identifier.type === 1) && (identifier.type >= 0 ||  identifier.type <= 2);
+  })
 
   // turn type and subtype ids into strings
-  let identifiersWithCompoundTypes = data.map((identifier) => {
+  let identifiersWithCompoundTypes = filteredData.map((identifier) => {
     let compoundType = types[identifier.type];
 
-    if(identifier.type >= typesCount) {
-      compoundType = 'Unknown Identifier';
-    }
-
-    if(identifier.subtype > 0 && identifier.subtype < subtypesCount) {
+    if(identifier.subtype > 0) {
       compoundType = `${compoundType} (${subtypes[identifier.subtype]})`;
     }
 

--- a/tests/title-show-test.js
+++ b/tests/title-show-test.js
@@ -23,7 +23,8 @@ describeApplication('TitleShow', function() {
       this.server.create('identifier', { type: 1, subtype: 1, id: '978-0547928210' }),
       this.server.create('identifier', { type: 1, subtype: 1, id: '978-0547928203' }),
       this.server.create('identifier', { type: 1, subtype: 2, id: '978-0547928197' }),
-      this.server.create('identifier', { type: 1, subtype: 0, id: '978-0547928227' })
+      this.server.create('identifier', { type: 1, subtype: 0, id: '978-0547928227' }),
+      this.server.create('identifier', { type: 8, subtype: 49, id: 'someothertypeofid' })
     ];
     title.contributors = [
       this.server.create('contributor', { type: 'author', contributor: 'Writer, Sally' }),
@@ -64,6 +65,10 @@ describeApplication('TitleShow', function() {
 
     it('does not show a subtype for an identifier when none exists', function() {
       expect(TitleShowPage.identifiersList[2]).to.equal('ISBN978-0547928227');
+    });
+
+    it('does not show identifiers that are not ISSN or ISBN', function() {
+      expect(TitleShowPage.identifiersList.length).to.equal(3);
     });
 
     it('displays the authors', function() {


### PR DESCRIPTION
We only want to see these identifiers.

Subtype | Type | UI Display Label
-- | -- | --
Print = 1 | ISSN = 0 | ISSN (Print)
Print = 1 | ISBN = 1 | ISBN (Print)
Online= 2 | ISSN = 0 | ISSN (Online)
Online = 2 | ISBN = 1 | ISBN (Online)

(I'm also showing ISSN and ISBN with subtype 0.)
