### PR TITLE
View and set backend settings

### DIFF
--- a/demo/boot-mirage.js
+++ b/demo/boot-mirage.js
@@ -5,4 +5,4 @@ import startMirage from '../mirage';
 * that this file will _not_ be include in the build at all if mirage
 * is disabled. Also, it will not included in test builds.
 */
-window.mirage = startMirage();
+window.mirage = startMirage(process.env.MIRAGE_SCENARIO);

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -1,11 +1,31 @@
 import { okapi } from 'stripes-config'; // eslint-disable-line import/no-unresolved
 import { Response } from 'mirage-server';
 
-export default function () {
-  // Okapi configs
+export default function configure() {
   this.urlPrefix = okapi.url;
+
+  // okapi endpoints
   this.get('/_/version', () => '0.0.0');
-  this.get('/_/proxy/modules', []);
+
+  this.get('/_/proxy/modules', [{
+    id: 'mod-kb-ebsco',
+    name: 'kb-ebsco'
+  }]);
+
+  this.get('/_/proxy/modules/mod-kb-ebsco', {
+    id: 'mod-kb-ebsco',
+    name: 'kb-ebsco',
+    provides: [{
+      id: 'eholdings',
+      version: '0.1.0',
+      handlers: [{
+        methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
+        pathPattern: '/eholdings/*'
+      }]
+    }],
+    permissionSets: []
+  });
+
   this.get('/saml/check', {
     ssoEnabled: false
   });
@@ -44,6 +64,32 @@ export default function () {
 
   // e-holdings endpoints
   this.namespace = 'eholdings';
+
+  // status
+  this.get('/status', {
+    data: {
+      type: 'status',
+      attributes: {
+        'is-configuration-valid': true
+      }
+    }
+  });
+
+  // configuration
+  this.get('/configuration', {
+    data: {
+      type: 'configuration',
+      attributes: {
+        'customer-id': 'some-valid-customer-id',
+        'api-key': 'some-valid-api-key'
+      }
+    }
+  });
+
+  this.put('/configuration', (_, request) => {
+    let data = JSON.parse(request.requestBody);
+    return data;
+  });
 
   // Package resources
   this.get('/packages', ({ packages }, request) => {

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -1,4 +1,4 @@
-export default function (server) {
+export default function defaultScenario(server) {
   function createVendor(name, packages = []) {
     let vendor = server.create('vendor', {
       vendorName: name,
@@ -71,6 +71,6 @@ export default function (server) {
   ]);
 
   server.createList('vendor', 5, 'withPackagesAndTitles', {
-    packagesTotal: () => Math.floor(Math.random() * 10) + 1
+    get packagesTotal() { return Math.floor(Math.random() * 10) + 1; }
   });
 }

--- a/mirage/scenarios/load-error-backend.js
+++ b/mirage/scenarios/load-error-backend.js
@@ -1,0 +1,5 @@
+export default function loadErrorBackendScenario(server) {
+  server.get('/status', {
+    error: 'An error has occurred'
+  }, 500);
+}

--- a/mirage/scenarios/no-backend.js
+++ b/mirage/scenarios/no-backend.js
@@ -1,0 +1,6 @@
+export default function noBackendScenario(server) {
+  let ns = server.namespace;
+  server.namespace = '';
+  server.get('/_/proxy/modules', []);
+  server.namespace = ns;
+}

--- a/mirage/scenarios/unconfigured-backend.js
+++ b/mirage/scenarios/unconfigured-backend.js
@@ -1,0 +1,20 @@
+export default function unconfiguredBackendScenario(server) {
+  server.get('/status', {
+    data: {
+      type: 'status',
+      attributes: {
+        'is-configuration-valid': false
+      }
+    }
+  });
+
+  server.get('/configuration', {
+    data: {
+      type: 'configuration',
+      attributes: {
+        'customer-id': '',
+        'api-key': ''
+      }
+    }
+  });
+}

--- a/mirage/start.js
+++ b/mirage/start.js
@@ -5,15 +5,9 @@ import baseConfig from './config';
 import '../tests/force-fetch-polyfill';
 
 const environment = process.env.NODE_ENV;
-const moduleTypes = ['factories', 'fixtures', 'models', 'serializers', 'identity-managers'];
+const moduleTypes = ['scenarios', 'factories', 'fixtures', 'models', 'serializers', 'identity-managers'];
 
-// don't load scenarios in the 'test' environment since you want to
-// create the server configuration by hand to correspond to each test case.
-if (environment !== 'test') {
-  moduleTypes.push('scenarios');
-}
-
-let modules = moduleTypes.reduce((memo, name) => {
+let allModules = moduleTypes.reduce((memo, name) => {
   memo[camelize(name)] = {};
   return memo;
 }, {});
@@ -26,13 +20,30 @@ req.keys().forEach((modulePath) => {
   const moduleType = moduleParts[1];
   const moduleName = moduleParts[2];
 
-  if (moduleName && modules[moduleType]) {
+  if (moduleName && allModules[moduleType]) {
     const moduleKey = camelize(moduleName.replace('.js', ''));
-    modules[moduleType][moduleKey] = req(modulePath).default;
+    allModules[moduleType][moduleKey] = req(modulePath).default;
   }
 });
 
-export default function startMirage() {
+let { scenarios, ...modules } = allModules;
+
+export default function startMirage(...scenarioNames) {
   let options = Object.assign(modules, { environment, baseConfig });
-  return new Mirage(options);
+  let server = new Mirage(options);
+
+  // mirage does not load our factories outside of testing when we do
+  // not declare a default scenario, so we load them ourselves
+  if (environment !== 'test') {
+    server.loadFactories(modules.factories);
+  }
+
+  // mirage only loads a `default` scenario for us out of the box, so
+  // instead we run any scenarios after we initialize mirage
+  scenarioNames.filter(Boolean).forEach((scenarioName) => {
+    let scenario = scenarios[camelize(scenarioName)];
+    if (scenario) scenario(server);
+  });
+
+  return server;
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint ./"
   },
   "devDependencies": {
-    "@folio/stripes-core": "thefrontside/stripes-core#jc/webpack-css",
+    "@folio/stripes-core": "thefrontside/stripes-core#master",
     "babel-core": "^6.25.0",
     "babel-eslint": "^8.0.1",
     "babel-loader": "^7.1.1",
@@ -50,8 +50,9 @@
   },
   "stripes": {
     "type": "app",
-    "displayName": "e-holdings",
+    "displayName": "eHoldings",
     "route": "/eholdings",
+    "hasSettings": true,
     "okapiInterfaces": {
       "kb-ebsco": "0.1.0"
     }

--- a/src/components/error-screen/error-screen.css
+++ b/src/components/error-screen/error-screen.css
@@ -1,0 +1,4 @@
+.eholdings-back-end-error {
+  max-width: 60em;
+  padding: 2em;
+}

--- a/src/components/error-screen/failed-backend.js
+++ b/src/components/error-screen/failed-backend.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import KeyValueLabel from '../key-value-label';
+import styles from './error-screen.css';
+
+export default function FailedBackendErrorScreen() {
+  return (
+    <div className={styles['eholdings-back-end-error']} data-test-eholdings-application-rejected>
+      <KeyValueLabel label="Error">
+        <h1>Could not retrieve configuration information</h1>
+      </KeyValueLabel>
+      <p>There was a server error while retrieving your knowledge base configuration.</p>
+    </div>
+  );
+}

--- a/src/components/error-screen/invalid-backend.js
+++ b/src/components/error-screen/invalid-backend.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import KeyValueLabel from '../key-value-label';
+import styles from './error-screen.css';
+
+export default function InvalidBackendErrorScreen() {
+  return (
+    <div className={styles['eholdings-back-end-error']} data-test-eholdings-unconfigured-backend>
+      <KeyValueLabel label="Error">
+        <h1>Knowledge base not configured</h1>
+      </KeyValueLabel>
+      <p>The eHoldings application detected the presence of a knowledge base, but the knowledge base does not appear to be configured.</p>
+      <p>Please configure the knowledge base with your credentials in <Link to="/settings/eholdings">Settings/eHoldings</Link>.</p>
+    </div>
+  );
+}

--- a/src/components/error-screen/no-backend.js
+++ b/src/components/error-screen/no-backend.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import KeyValueLabel from '../key-value-label';
+import styles from './error-screen.css';
+
+export default function NoBackendErrorScreen() {
+  return (
+    <div className={styles['eholdings-back-end-error']} data-test-eholdings-no-backend>
+      <KeyValueLabel label="Error">
+        <h1>No knowledge base detected</h1>
+      </KeyValueLabel>
+      <p>The eHoldings package requires a knowledge base to be present for proper operation.</p>
+      <p>Please install an appropriate backend module with your instance of OKAPI.</p>
+    </div>
+  );
+}

--- a/src/components/search-form/search-form.css
+++ b/src/components/search-form/search-form.css
@@ -1,4 +1,4 @@
-@import '@folio/stripes-core/src/components/variables';
+@import '@folio/stripes-components/lib/variables';
 
 .search-form-container {
   padding: 1em;

--- a/src/components/settings/index.js
+++ b/src/components/settings/index.js
@@ -1,0 +1,1 @@
+export { default } from './settings';

--- a/src/components/settings/settings.css
+++ b/src/components/settings/settings.css
@@ -1,0 +1,83 @@
+@import '@folio/stripes-components/lib/variables';
+
+.eholdings-settings {
+  padding: 2em;
+  width: 100%;
+
+  & form {
+    max-width: 40em;
+  }
+}
+
+.eholdings-settings-form-actions {
+  @media(min-width: 641px){
+    display: flex;
+    flex-direction: row-reverse;
+  }
+
+  & button {
+    background: #fff;
+    border: 1px solid var(--primary);
+    border-radius: 0.4em;
+    color: var(--primary);
+    margin: 0.5em 0;
+    padding: 0.57em;
+    text-align: center;
+    text-decoration: none;
+    user-select: none;
+    vertical-align: middle;
+    white-space: nowrap;
+    width: 100%;
+
+    @media(min-width: 641px){
+      display: inline-block;
+      margin: 0.5em;
+      padding: 0.36em 0.57em;
+      width: auto;
+    }
+  }
+
+  & button[type=submit] {
+    background: var(--primary);
+    color: #fff;
+  }
+}
+
+.eholdings-settings-field {
+  margin-bottom: var(--controlMarginBottom);
+
+  & label {
+    display: block;
+    font-size: .8em;
+    font-weight: bold;
+    margin-bottom: 4px;
+    text-transform: Uppercase;
+    color: var(--labelColor);
+  }
+
+  & input {
+    height: var(--controlHeight);
+    min-height: var(--controlHeight);
+    margin-bottom: var(--controlMarginBottom);
+    padding: 4px;
+    border: 1px solid var(--inputBorderColor);
+    width: 100%;
+  }
+
+  &.has-error {
+    & label {
+      color: #900;
+    }
+
+    & input {
+      border-color: #900;
+    }
+  }
+}
+
+.eholdings-settings-save-error {
+  display: flex;
+  align-items: center;
+  flex-grow: 1;
+  color: var(--error);
+}

--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -1,0 +1,157 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames/bind';
+import styles from './settings.css';
+
+const cx = classNames.bind(styles);
+
+export default class Settings extends Component {
+  static propTypes = {
+    settings: PropTypes.object.isRequired,
+    update: PropTypes.object.isRequired,
+    onSubmit: PropTypes.func.isRequired
+  };
+
+  state = {
+    customerId: this.props.settings['customer-id'] || '',
+    apiKey: this.props.settings['api-key'] || '',
+    invalidCustomerId: false,
+    invalidApiKey: false
+  };
+
+  componentWillReceiveProps(nextProps) {
+    let { customerId, apiKey } = this.state;
+    let { update, settings: next } = nextProps;
+
+    let isDirty = customerId !== next['customer-id'] || apiKey !== next['api-key'];
+
+    if (update.isResolved && isDirty) {
+      this.setState({
+        customerId: next['customer-id'],
+        apiKey: next['api-key']
+      });
+    }
+  }
+
+  handleSubmit = (e) => {
+    let { customerId, apiKey } = this.state;
+
+    e.preventDefault();
+
+    this.props.onSubmit({
+      customerId,
+      apiKey
+    });
+  };
+
+  handleClear = (e) => {
+    let settings = this.props.settings;
+
+    e.preventDefault();
+
+    this.setState({
+      customerId: settings['customer-id'],
+      apiKey: settings['api-key'],
+      invalidCustomerId: false,
+      invalidApiKey: false
+    });
+  };
+
+  updateCustomerId = (e) => {
+    this.validateCustomerId(e);
+    this.setState({ customerId: e.target.value });
+  };
+
+  updateApiKey = (e) => {
+    this.validateApiKey(e);
+    this.setState({ apiKey: e.target.value });
+  };
+
+  validateCustomerId = (e) => {
+    if (e.target.value.length > 0) {
+      this.setState({ invalidCustomerId: false });
+    } else {
+      this.setState({ invalidCustomerId: true });
+    }
+  };
+
+  validateApiKey = (e) => {
+    if (e.target.value.length > 0) {
+      this.setState({ invalidApiKey: false });
+    } else {
+      this.setState({ invalidApiKey: true });
+    }
+  };
+
+  render() {
+    let { customerId, apiKey, invalidCustomerId, invalidApiKey } = this.state;
+    let { settings, update } = this.props;
+
+    let isFresh = !customerId && !apiKey;
+    let isDirty = customerId !== settings['customer-id'] || apiKey !== settings['api-key'];
+    let isValid = customerId && apiKey;
+
+    return (
+      <div className={styles['eholdings-settings']}>
+        <h1>eHoldings</h1>
+
+        <h2 data-test-eholdings-settings-description>
+          EBSCO Knowledge Base
+        </h2>
+
+        <form
+          onSubmit={this.handleSubmit}
+          data-test-eholdings-settings
+        >
+          {update.isRejected && (
+            <p data-test-eholdings-settings-error>
+              {update.error.length ? update.error[0].message : update.error.message}
+            </p>
+          )}
+
+          <div
+            data-test-eholdings-settings-customerid
+            className={cx(styles['eholdings-settings-field'], {
+              'has-error': invalidCustomerId
+            })}
+          >
+            <label htmlFor="eholdings-settings-customerid">Customer ID</label>
+            <input
+              id="eholdings-settings-customerid"
+              type="text"
+              autoComplete="off"
+              value={customerId}
+              onChange={this.updateCustomerId}
+              onBlur={this.validateCustomerId}
+            />
+          </div>
+
+          <div
+            data-test-eholdings-settings-apikey
+            className={cx(styles['eholdings-settings-field'], {
+              'has-error': invalidApiKey
+            })}
+          >
+            <label htmlFor="eholdings-settings-apikey">API Key</label>
+            <input
+              id="eholdings-settings-apikey"
+              type="text"
+              autoComplete="off"
+              value={apiKey}
+              onChange={this.updateApiKey}
+              onBlur={this.validateApiKey}
+            />
+          </div>
+
+          {(isFresh || isDirty) && (
+            <div className={styles['eholdings-settings-form-actions']} data-test-eholdings-settings-actions>
+              <button type="submit" disabled={!isValid || update.isPending}>Save</button>
+              <button type="reset" onClick={this.handleClear}>Cancel</button>
+              <div className={styles['eholdings-settings-save-error']} data-test-eholdings-settings-error>{update.message}</div>
+            </div>
+          )}
+        </form>
+      </div>
+    );
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import { Route, Switch, Redirect } from './router';
 
 import { reducer, epics } from './redux';
 
+import ApplicationRoute from './routes/application';
 import SearchRoute from './routes/search';
 import VendorSearchResultsRoute from './routes/vendor/vendor-search-results';
 import PackageSearchResultsRoute from './routes/package/package-search-results';
@@ -14,6 +15,8 @@ import PackageShow from './routes/package/package-show';
 import CustomerResourceShow from './routes/customer-resource/customer-resource-show';
 import TitleShow from './routes/title/title-show';
 
+import SettingsRoute from './routes/settings';
+
 export default class EHoldings extends Component {
   static propTypes = {
     match: PropTypes.shape({
@@ -21,7 +24,8 @@ export default class EHoldings extends Component {
     }).isRequired,
     stripes: PropTypes.shape({
       intl: PropTypes.object.isRequired
-    }).isRequired
+    }).isRequired,
+    showSettings: PropTypes.bool
   };
 
   static contextTypes = {
@@ -45,22 +49,29 @@ export default class EHoldings extends Component {
   }
 
   render() {
-    const rootPath = this.props.match.path;
+    let {
+      showSettings,
+      match: { path: rootPath }
+    } = this.props;
 
-    return (
-      <Switch>
-        <Route path={`${rootPath}/search/:searchType(vendors|packages|titles)`} component={SearchRoute}>
-          <Route path={`${rootPath}/search/vendors`} exact component={VendorSearchResultsRoute} />
-          <Route path={`${rootPath}/search/packages`} exact component={PackageSearchResultsRoute} />
-          <Route path={`${rootPath}/search/titles`} exact component={TitleSearchResultsRoute} />
-        </Route>
+    return showSettings ? (
+      <Route path={rootPath} component={SettingsRoute} />
+    ) : (
+      <Route path={rootPath} component={ApplicationRoute}>
+        <Switch>
+          <Route path={`${rootPath}/search/:searchType(vendors|packages|titles)`} component={SearchRoute}>
+            <Route path={`${rootPath}/search/vendors`} exact component={VendorSearchResultsRoute} />
+            <Route path={`${rootPath}/search/packages`} exact component={PackageSearchResultsRoute} />
+            <Route path={`${rootPath}/search/titles`} exact component={TitleSearchResultsRoute} />
+          </Route>
 
-        <Route path={`${rootPath}/vendors/:vendorId`} exact component={VendorShow} />
-        <Route path={`${rootPath}/vendors/:vendorId/packages/:packageId`} exact component={PackageShow} />
-        <Route path={`${rootPath}/vendors/:vendorId/packages/:packageId/titles/:titleId`} exact component={CustomerResourceShow} />
-        <Route path={`${rootPath}/titles/:titleId`} exact component={TitleShow} />
-        <Route render={() => (<Redirect to={`${rootPath}/search/vendors`} />)} />
-      </Switch>
+          <Route path={`${rootPath}/vendors/:vendorId`} exact component={VendorShow} />
+          <Route path={`${rootPath}/vendors/:vendorId/packages/:packageId`} exact component={PackageShow} />
+          <Route path={`${rootPath}/vendors/:vendorId/packages/:packageId/titles/:titleId`} exact component={CustomerResourceShow} />
+          <Route path={`${rootPath}/titles/:titleId`} exact component={TitleShow} />
+          <Route render={() => (<Redirect to={`${rootPath}/search/vendors`} />)} />
+        </Switch>
+      </Route>
     );
   }
 }

--- a/src/redux/application.js
+++ b/src/redux/application.js
@@ -1,0 +1,89 @@
+import { combineReducers } from 'redux';
+import { combineEpics } from 'redux-observable';
+import {
+  REQUEST_RESOLVE,
+  REQUEST_REJECT,
+  createRequestReducer,
+  createRequestEpic,
+  createRequestCreator
+} from './request';
+
+export const getBackendStatus = createRequestCreator('backend-status');
+export const getBackendConfig = createRequestCreator('backend-configuration');
+export const updateBackendConfig = createRequestCreator(
+  'update-backend-configuration',
+  { method: 'PUT' }
+);
+
+export const applicationReducer = combineReducers({
+  status: createRequestReducer({
+    name: 'backend-status',
+    initialContent: {}
+  }),
+  config: createRequestReducer({
+    name: 'backend-configuration',
+    initialContent: {},
+    handleRequests: {
+      'update-backend-configuration': (state, action) => {
+        if (action.type === REQUEST_RESOLVE) {
+          return {
+            ...state,
+            content: {
+              ...state.content,
+              ...action.payload
+            }
+          };
+        } else {
+          return state;
+        }
+      }
+    }
+  }),
+  update: createRequestReducer({
+    name: 'update-backend-configuration',
+    handleRequests: {
+      'update-backend-configuration': (state, action) => {
+        if (action.type === REQUEST_REJECT) {
+          let errors = action.error.errors;
+          let message = errors != null ? errors[0].detail : 'there was a server error while attempting to update the config';
+          return {
+            ...state,
+            message
+          };
+        } else {
+          return state;
+        }
+      }
+    }
+  })
+});
+
+export const applicationEpics = combineEpics(
+  createRequestEpic({
+    name: 'backend-status',
+    endpoint: 'eholdings/status',
+    // TODO: generic JSON deserialization
+    deserialize: ({ data: { attributes } }) => ({ ...attributes })
+  }),
+  createRequestEpic({
+    name: 'backend-configuration',
+    endpoint: 'eholdings/configuration',
+    // TODO: generic JSON deserialization
+    deserialize: ({ data: { attributes } }) => ({ ...attributes })
+  }),
+  createRequestEpic({
+    name: 'update-backend-configuration',
+    endpoint: 'eholdings/configuration',
+    // TODO: generic JSON serialization & deserialization
+    deserialize: ({ data: { attributes } }) => ({ ...attributes }),
+    serialize: ({ customerId, apiKey }) => ({
+      data: {
+        type: 'configurations',
+        attributes: {
+          'customer-id': customerId,
+          'api-key': apiKey
+        }
+      }
+    })
+  })
+);

--- a/src/redux/index.js
+++ b/src/redux/index.js
@@ -2,6 +2,11 @@ import { combineReducers } from 'redux';
 import { combineEpics } from 'redux-observable';
 
 import {
+  applicationReducer,
+  applicationEpics
+} from './application';
+
+import {
   searchReducer,
   searchEpic
 } from './search';
@@ -23,6 +28,7 @@ import {
 } from './customer-resource';
 
 export const reducer = combineReducers({
+  application: applicationReducer,
   search: searchReducer,
   vendor: vendorReducer,
   package: packageReducer,
@@ -31,6 +37,7 @@ export const reducer = combineReducers({
 });
 
 export const epics = combineEpics(
+  applicationEpics,
   searchEpic,
   vendorEpics,
   packageEpics,

--- a/src/routes/application.js
+++ b/src/routes/application.js
@@ -1,0 +1,57 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import Icon from '@folio/stripes-components/lib/Icon';
+
+import { getBackendStatus } from '../redux/application';
+import NoBackendErrorScreen from '../components/error-screen/no-backend';
+import FailedBackendErrorScreen from '../components/error-screen/failed-backend';
+import InvalidBackendErrorScreen from '../components/error-screen/invalid-backend';
+
+class ApplicationRoute extends Component {
+  static propTypes = {
+    showSettings: PropTypes.bool,
+    children: PropTypes.node.isRequired,
+    interfaces: PropTypes.object,
+    status: PropTypes.object.isRequired,
+    getBackendStatus: PropTypes.func.isRequired
+  }
+
+  componentWillMount() {
+    this.props.getBackendStatus();
+  }
+
+  render() {
+    let {
+      status,
+      interfaces: { eholdings: version },
+      showSettings,
+      children
+    } = this.props;
+
+    return (
+      <div className="eholdings-application" data-test-eholdings-application style={{ width: '100%' }}>
+        {version ? (status.isPending ? (
+          <Icon icon="spinner-ellipsis" />
+        ) : status.isRejected ? (
+          <FailedBackendErrorScreen />
+        ) : status.isResolved && (
+          !(showSettings || status.content['is-configuration-valid'])
+            ? <InvalidBackendErrorScreen />
+            : children
+        )) : <NoBackendErrorScreen />}
+      </div>
+    );
+  }
+}
+
+export default connect(
+  ({
+    eholdings: { application },
+    discovery: { interfaces = {} }
+  }) => ({
+    status: application.status,
+    interfaces
+  }),
+  { getBackendStatus }
+)(ApplicationRoute);

--- a/src/routes/settings.js
+++ b/src/routes/settings.js
@@ -1,0 +1,44 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import Icon from '@folio/stripes-components/lib/Icon';
+import { getBackendConfig, updateBackendConfig } from '../redux/application';
+import View from '../components/settings';
+import ApplicationRoute from './application';
+
+// eslint-disable-next-line no-shadow
+class SettingsRoute extends Component {
+  static propTypes = {
+    application: PropTypes.object.isRequired,
+    getBackendConfig: PropTypes.func.isRequired,
+    updateBackendConfig: PropTypes.func.isRequired
+  };
+
+  componentWillMount() {
+    this.props.getBackendConfig();
+  }
+
+  render() {
+    let { application, updateBackendConfig } = this.props; // eslint-disable-line no-shadow
+
+    return (
+      <ApplicationRoute showSettings>
+        {application.config.isPending ? (
+          <Icon icon='spinner-ellipsis' />
+        ) : (
+          <View
+            settings={application.config.content}
+            update={application.update}
+            onSubmit={updateBackendConfig}
+          />
+        )}
+      </ApplicationRoute>
+    );
+  }
+}
+
+export default connect(
+  ({ eholdings: { application } }) => ({ application }),
+  { getBackendConfig, updateBackendConfig }
+)(SettingsRoute);

--- a/tests/backend-configuration-test.js
+++ b/tests/backend-configuration-test.js
@@ -1,0 +1,226 @@
+/* global describe, beforeEach */
+import { expect } from 'chai';
+import it from './it-will';
+
+import { Response } from 'mirage-server';
+
+import { describeApplication } from './helpers';
+import ApplicationPage from './pages/application';
+import SettingsPage from './pages/settings';
+
+describeApplication('Error retrieving backend', {
+  scenarios: ['load-error-backend'],
+
+  suite() {
+    describe('when trying to use the app', () => {
+      beforeEach(function () {
+        return this.visit('/eholdings', () => expect(ApplicationPage.$root).to.exist);
+      });
+
+      it('informs user that an error has occurred', () => {
+        expect(ApplicationPage.backendLoadError).to.be.true;
+      });
+    });
+  }
+});
+
+describeApplication('With no backend at all', {
+  scenarios: ['no-backend'],
+
+  suite() {
+    describe('when trying to use the app', () => {
+      beforeEach(function () {
+        return this.visit('/eholdings', () => expect(ApplicationPage.$root).to.exist);
+      });
+
+      it('blocks access to the eholdings app and tells me that I need to install a backend', () => {
+        expect(ApplicationPage.doesNotHaveBackend).to.be.true;
+      });
+    });
+  }
+});
+
+describeApplication('With unconfigured backend', {
+  scenarios: ['unconfigured-backend'],
+
+  suite() {
+    describe('when trying to use the app', () => {
+      beforeEach(function () {
+        return this.visit('/eholdings', () => expect(ApplicationPage.$root).to.exist);
+      });
+
+      it('blocks access to the eholdings app and points you to the configuration screen', () => {
+        expect(ApplicationPage.backendNotConfigured).to.be.true;
+      });
+    });
+
+    describe('when visiting settings', () => {
+      beforeEach(function () {
+        return this.visit('/settings/eholdings', () => expect(SettingsPage.$root).to.exist);
+      });
+
+      it('shows the form action buttons', () => {
+        expect(SettingsPage.$actions).to.exist;
+      });
+
+      describe('filling in incomplete data', () => {
+        beforeEach(() => {
+          SettingsPage.blurCustomerId();
+          SettingsPage.blurApiKey();
+        });
+
+        it('displays an errored state for the blank customer id', () => {
+          expect(SettingsPage.customerIdFieldIsInvalid).to.be.true;
+        });
+
+        it('displays an errored state for the blank api key', () => {
+          expect(SettingsPage.apiKeyFieldIsInvalid).to.be.true;
+        });
+      });
+
+      describe('filling in incomplete data, then filling in more data', () => {
+        beforeEach(() => {
+          SettingsPage.blurCustomerId();
+          SettingsPage.blurApiKey();
+
+          SettingsPage.fillIn({
+            customerId: 'some-customer-id',
+            apiKey: 'some-api-key'
+          });
+        });
+
+        it('does not display an error state for customer id', () => {
+          expect(SettingsPage.customerIdFieldIsInvalid).to.be.false;
+        });
+
+        it('does not display an error state for api key', () => {
+          expect(SettingsPage.apiKeyFieldIsInvalid).to.be.false;
+        });
+      });
+    });
+  }
+});
+
+describeApplication('With valid backend configuration', () => {
+  describe('when visiting settings', () => {
+    beforeEach(function () {
+      return this.visit('/settings/eholdings', () => expect(SettingsPage.$root).to.exist);
+    });
+
+    it('has a description of itself', () => {
+      expect(SettingsPage.description).to.equal('EBSCO Knowledge Base');
+    });
+
+    it('has a field for the ebsco customer id', () => {
+      expect(SettingsPage.$customerIdField).to.exist;
+    });
+
+    it('has a field for the ebsco RM API key', () => {
+      expect(SettingsPage.$apiKeyField).to.exist;
+    });
+
+    it.still('does not have visible form action buttons', () => {
+      expect(SettingsPage.$actions).to.not.exist;
+    });
+
+    describe('filling in invalid data', function() {
+      beforeEach(function() {
+          this.server.put('/configuration', (_, request) => {
+            return new Response(422, {}, {
+              "errors":[{
+                "title":"Invalid base",
+                "detail":"RM-API Credentials Are Invalid",
+                "source":{}
+              }],
+              "jsonapi":{"version":"1.0"}
+            });
+          });
+        return SettingsPage.fillIn({
+          customerId: 'totally-bogus-customer-id',
+          apiKey: 'totally-bogus-api-key'
+        }).then(()=> {
+          return SettingsPage.save();
+        });
+      });
+      it('reports the error to the interface', function() {
+        expect(SettingsPage.errorText).to.equal('RM-API Credentials Are Invalid');
+      });
+    });
+
+
+    describe('filling in complete data', () => {
+      beforeEach(() => {
+        return SettingsPage.fillIn({
+          customerId: 'some-customer-id',
+          apiKey: 'some-api-key'
+        });
+      });
+
+      it('shows the form actions', () => {
+        expect(SettingsPage.$actions).to.exist;
+      });
+
+      describe('saving the changes', () => {
+        beforeEach(() => {
+          SettingsPage.save();
+        });
+
+        // mirage may respond too quick to properly test loading states
+        it.skip('disables the save button', () => {
+          expect(SettingsPage.$saveButton).to.have.prop('disabled', true);
+        });
+
+        it.skip('indicates that it is working');
+
+        describe('when the changes succeed', () => {
+          it('hides the form actions', () => {
+            expect(SettingsPage.$actions).to.not.exist;
+          });
+        });
+      });
+
+      describe('when saving the changes fail', () => {
+        beforeEach(function () {
+          this.server.put('/configuration', [{
+            message: 'an error has occurred'
+          }], 500);
+
+          SettingsPage.save();
+        });
+
+        it.still('still shows the form action buttons', () => {
+          expect(SettingsPage.$actions).to.exist;
+        });
+
+        it('enables the save button', () => {
+          expect(SettingsPage.$saveButton).to.have.prop('disabled', false);
+        });
+
+        it('shows an error message', () => {
+          expect(SettingsPage.hasErrors).to.be.true;
+        });
+      });
+
+      describe('when the validation fails', () => {
+        beforeEach(() => {
+          SettingsPage.fillIn({ customerId: '' });
+        });
+
+        it('does not enable the save button', () => {
+          expect(SettingsPage.$saveButton).to.have.prop('disabled', true);
+        });
+      });
+
+      describe('then hitting the cancel button', () => {
+        beforeEach(() => {
+          SettingsPage.cancel();
+        });
+
+        it('reverts the changes', () => {
+          expect(SettingsPage.$customerIdField).to.have.value('some-valid-customer-id');
+          expect(SettingsPage.$apiKeyField).to.have.value('some-valid-api-key');
+        });
+      });
+    });
+  });
+});

--- a/tests/backend-configuration-test.js
+++ b/tests/backend-configuration-test.js
@@ -1,8 +1,8 @@
 /* global describe, beforeEach */
+import { Response } from 'mirage-server';
+
 import { expect } from 'chai';
 import it from './it-will';
-
-import { Response } from 'mirage-server';
 
 import { describeApplication } from './helpers';
 import ApplicationPage from './pages/application';
@@ -123,26 +123,26 @@ describeApplication('With valid backend configuration', () => {
       expect(SettingsPage.$actions).to.not.exist;
     });
 
-    describe('filling in invalid data', function() {
-      beforeEach(function() {
-          this.server.put('/configuration', (_, request) => {
-            return new Response(422, {}, {
-              "errors":[{
-                "title":"Invalid base",
-                "detail":"RM-API Credentials Are Invalid",
-                "source":{}
-              }],
-              "jsonapi":{"version":"1.0"}
-            });
+    describe('filling in invalid data', () => {
+      beforeEach(function () {
+        this.server.put('/configuration', () => {
+          return new Response(422, {}, {
+            errors: [{
+              title: 'Invalid base',
+              detail: 'RM-API Credentials Are Invalid',
+              source: {}
+            }],
+            jsonapi: { version: '1.0' }
           });
+        });
         return SettingsPage.fillIn({
           customerId: 'totally-bogus-customer-id',
           apiKey: 'totally-bogus-api-key'
-        }).then(()=> {
+        }).then(() => {
           return SettingsPage.save();
         });
       });
-      it('reports the error to the interface', function() {
+      it('reports the error to the interface', () => {
         expect(SettingsPage.errorText).to.equal('RM-API Credentials Are Invalid');
       });
     });

--- a/tests/harness.js
+++ b/tests/harness.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import startMirage from '../mirage';
 
 /* eslint-disable import/first */
 import createMemoryHistory from 'history/createMemoryHistory';
@@ -30,7 +29,6 @@ export default class TestHarness extends Component {
     this.logger = configureLogger(config);
     this.epics = configureEpics();
     this.store = configureStore({ okapi }, this.logger, this.epics);
-    this.mirage = startMirage();
 
     this.history = createMemoryHistory();
 
@@ -38,10 +36,6 @@ export default class TestHarness extends Component {
 
     // While we have disableAuth on, manually tell our app Okapi is ready
     this.store.dispatch(setOkapiReady());
-  }
-
-  componentWillUnmount() {
-    this.mirage.shutdown();
   }
 
   /**

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -5,6 +5,7 @@ import chaiJquery from 'chai-jquery';
 import $ from 'jquery';
 import { render, unmountComponentAtNode } from 'react-dom';
 import { convergeOn } from './it-will';
+import startMirage from '../mirage/start';
 import TestHarness from './harness';
 
 // use jquery matchers
@@ -36,20 +37,24 @@ export function describeApplication(name, setup, describe = window.describe) {
       rootElement.id = 'react-testing';
       document.body.appendChild(rootElement);
 
-      this.app = render(<TestHarness />, rootElement);
-      this.server = this.app.mirage;
+      this.server = startMirage(setup.scenarios);
       this.server.logging = false;
+
+      this.app = render(<TestHarness />, rootElement);
 
       this.visit = visit.bind(null, this); // eslint-disable-line no-use-before-define
     });
 
-    afterEach(() => {
+    afterEach(function () {
+      this.server.shutdown();
       unmountComponentAtNode(rootElement);
       document.body.removeChild(rootElement);
       rootElement = null;
     });
 
-    setup.call(this);
+    let doSetup = typeof setup.suite === 'function' ? setup.suite : setup;
+
+    doSetup.call(this);
   });
 }
 

--- a/tests/pages/application.js
+++ b/tests/pages/application.js
@@ -1,0 +1,16 @@
+import $ from 'jquery';
+
+export default {
+  get $root() {
+    return $('[data-test-eholdings-application]');
+  },
+  get doesNotHaveBackend() {
+    return $('[data-test-eholdings-no-backend]').length > 0;
+  },
+  get backendNotConfigured() {
+    return $('[data-test-eholdings-unconfigured-backend]').length > 0;
+  },
+  get backendLoadError() {
+    return $('[data-test-eholdings-application-rejected]').length > 0;
+  }
+};

--- a/tests/pages/helpers.js
+++ b/tests/pages/helpers.js
@@ -1,0 +1,33 @@
+import $ from 'jquery';
+import { expect } from 'chai';
+import { triggerChange } from '../helpers';
+import { convergeOn } from '../it-will';
+
+export function fillIn(el, val) {
+  if (typeof val === 'undefined') {
+    return Promise.resolve();
+  }
+
+  let $input = $(el).val(val);
+  triggerChange($input.get(0));
+
+  return convergeOn(() => {
+    expect($input.val()).to.equal(val);
+  });
+}
+
+export function blur(el) {
+  let node = $(el).get(0);
+
+  if (node) {
+    let focusEvent = document.createEvent('UIEvents');
+    focusEvent.initEvent('focus', false, false);
+    node.dispatchEvent(focusEvent);
+
+    let blurEvent = document.createEvent('UIEvents');
+    blurEvent.initEvent('blur', false, false);
+    node.dispatchEvent(blurEvent);
+  } else {
+    throw new Error('Blur node does not exist.');
+  }
+}

--- a/tests/pages/settings.js
+++ b/tests/pages/settings.js
@@ -1,0 +1,68 @@
+import $ from 'jquery';
+import { fillIn, blur } from './helpers';
+
+export default {
+  get $root() {
+    return $('[data-test-eholdings-settings]');
+  },
+  get $customerIdField() {
+    return $('[data-test-eholdings-settings-customerid] input');
+  },
+  get $apiKeyField() {
+    return $('[data-test-eholdings-settings-apikey] input');
+  },
+  get $actions() {
+    return $('[data-test-eholdings-settings-actions]');
+  },
+  get $saveButton() {
+    return this.$actions.find('[type="submit"]');
+  },
+  get $cancelButton() {
+    return this.$actions.find('[type="reset"]');
+  },
+
+  get description() {
+    return $('[data-test-eholdings-settings-description]').text();
+  },
+
+  get hasErrors() {
+    return $('[data-test-eholdings-settings-error]').length > 0;
+  },
+
+  get customerIdFieldIsInvalid() {
+    return $('[data-test-eholdings-settings-customerid] label').css('color') === 'rgb(153, 0, 0)' &&
+      $('[data-test-eholdings-settings-customerid] input').css('border-color') === 'rgb(153, 0, 0)';
+  },
+
+  get apiKeyFieldIsInvalid() {
+    return $('[data-test-eholdings-settings-apikey] label').css('color') === 'rgb(153, 0, 0)' &&
+      $('[data-test-eholdings-settings-apikey] input').css('border-color') === 'rgb(153, 0, 0)';
+  },
+
+  get errorText() {
+    return $('[data-test-eholdings-settings-error]').text();
+  },
+
+  fillIn({ customerId, apiKey }) {
+    return Promise.all([
+      fillIn(this.$customerIdField, customerId),
+      fillIn(this.$apiKeyField, apiKey)
+    ]);
+  },
+
+  blurCustomerId() {
+    blur(this.$customerIdField);
+  },
+
+  blurApiKey() {
+    blur(this.$apiKeyField);
+  },
+
+  save() {
+    this.$saveButton.click();
+  },
+
+  cancel() {
+    this.$cancelButton.click();
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,8 +3,8 @@
 
 
 "@folio/stripes-components@^1.5.0", "@folio/stripes-components@^1.6.0":
-  version "1.8.0"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-components/-/stripes-components-1.8.0.tgz#1116a86efdc06b9b2e365e889af7a16508bc2a1b"
+  version "1.9.0"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-components/-/stripes-components-1.9.0.tgz#75daa564c8a140d7ebce515e9101fd1daf068af2"
   dependencies:
     "@folio/stripes-form" "^0.8.1"
     "@folio/stripes-react-hotkeys" "^1.0.0"
@@ -16,17 +16,18 @@
     moment-range "^3.0.3"
     mousetrap "^1.6.1"
     prop-types "^15.5.10"
-    react "^15.3.2"
+    react "^15.6.1"
     react-dom "^15.6.1"
     react-flexbox-grid "1.1.3"
     react-overlays "^0.8.0"
     react-router-dom "^4.1.1"
+    react-test-renderer "^15.6.1"
     react-tether "0.5.7"
     redux-form "^7.0.3"
 
-"@folio/stripes-connect@folio-org/stripes-connect#3c2714a189c2296f389fc6ee4e79a7ee7c962949":
-  version "2.7.0"
-  resolved "https://codeload.github.com/folio-org/stripes-connect/tar.gz/3c2714a189c2296f389fc6ee4e79a7ee7c962949"
+"@folio/stripes-connect@^3.0.0-pre.1":
+  version "3.0.0"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-connect/-/stripes-connect-3.0.0.tgz#87634148bc68c2eed2acfc784474382f00cafaa6"
   dependencies:
     isomorphic-fetch "^2.2.1"
     lodash "^4.17.2"
@@ -39,12 +40,12 @@
     redux-crud "^3.0.0"
     uuid "^3.0.1"
 
-"@folio/stripes-core@thefrontside/stripes-core#jc/webpack-css":
+"@folio/stripes-core@thefrontside/stripes-core#master":
   version "2.7.0"
-  resolved "https://codeload.github.com/thefrontside/stripes-core/tar.gz/d145cd5d70898fbc952ed3503540deb6fded81a4"
+  resolved "https://codeload.github.com/thefrontside/stripes-core/tar.gz/30e267959a224cb01f7777c8f1586172090aca04"
   dependencies:
     "@folio/stripes-components" "^1.6.0"
-    "@folio/stripes-connect" folio-org/stripes-connect#3c2714a189c2296f389fc6ee4e79a7ee7c962949
+    "@folio/stripes-connect" "^3.0.0-pre.1"
     "@folio/stripes-logger" "^0.0.2"
     autoprefixer "^7.1.1"
     babel-core "^6.23.1"
@@ -61,6 +62,7 @@
     connect-history-api-fallback "^1.3.0"
     copy-webpack-plugin "^4.0.1"
     css-loader "^0.28.4"
+    duplicate-package-checker-webpack-plugin "^1.2.6"
     express "^4.14.0"
     extract-text-webpack-plugin "^3.0.0"
     hard-source-webpack-plugin "^0.4.4"
@@ -138,8 +140,8 @@
     react-dom "^15.6.1"
 
 abbrev@1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
 abstract-leveldown@~2.6.0, abstract-leveldown@~2.6.1:
   version "2.6.3"
@@ -154,7 +156,7 @@ accepts@1.3.3:
     mime-types "~2.1.11"
     negotiator "0.6.1"
 
-accepts@~1.3.3, accepts@~1.3.4:
+accepts@~1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.4.tgz#86246758c7dd6d21a6474ff084a4740ec05eb21f"
   dependencies:
@@ -212,8 +214,8 @@ ajv@^4.9.1:
     json-stable-stringify "^1.0.1"
 
 ajv@^5.0.0, ajv@^5.1.5, ajv@^5.2.0, ajv@^5.2.3:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.3.tgz#c06f598778c44c6b161abafe3466b81ad1814ed2"
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.4.tgz#3daf9a8b67221299fdae8d82d117ed8e6c80244b"
   dependencies:
     co "^4.6.0"
     fast-deep-equal "^1.0.0"
@@ -347,7 +349,7 @@ arraybuffer.slice@0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz#f33b2159f0532a3f3107a272c0ccfbd1ad2979ca"
 
-arrify@^1.0.0:
+arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
@@ -431,14 +433,14 @@ autoprefixer@^6.3.1:
     postcss-value-parser "^3.2.3"
 
 autoprefixer@^7.1.1:
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-7.1.4.tgz#960847dbaa4016bc8e8e52ec891cbf8f1257a748"
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-7.1.6.tgz#fb933039f74af74a83e71225ce78d9fd58ba84d7"
   dependencies:
-    browserslist "^2.4.0"
-    caniuse-lite "^1.0.30000726"
+    browserslist "^2.5.1"
+    caniuse-lite "^1.0.30000748"
     normalize-range "^0.1.2"
     num2fraction "^1.2.2"
-    postcss "^6.0.11"
+    postcss "^6.0.13"
     postcss-value-parser "^3.2.3"
 
 aws-sign2@~0.6.0:
@@ -513,7 +515,7 @@ babel-eslint@^8.0.1:
     babel-types "7.0.0-beta.0"
     babylon "7.0.0-beta.22"
 
-babel-generator@^6.26.0:
+babel-generator@^6.18.0, babel-generator@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.0.tgz#ac1ae20070b79f6e3ca1d3269613053774f20dc5"
   dependencies:
@@ -667,6 +669,13 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
+babel-jest@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-21.2.0.tgz#2ce059519a9374a2c46f2455b6fbef5ad75d863e"
+  dependencies:
+    babel-plugin-istanbul "^4.0.0"
+    babel-preset-jest "^21.2.0"
+
 babel-loader@^7.0.0, babel-loader@^7.1.1:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-7.1.2.tgz#f6cbe122710f1aa2af4d881c6d5b54358ca24126"
@@ -690,6 +699,18 @@ babel-plugin-check-es2015-constants@^6.22.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
   dependencies:
     babel-runtime "^6.22.0"
+
+babel-plugin-istanbul@^4.0.0:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz#6760cdd977f411d3e175bb064f2bc327d99b2b6e"
+  dependencies:
+    find-up "^2.1.0"
+    istanbul-lib-instrument "^1.7.5"
+    test-exclude "^4.1.1"
+
+babel-plugin-jest-hoist@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz#2cef637259bd4b628a6cace039de5fcd14dbb006"
 
 babel-plugin-react-transform@^2.0.2:
   version "2.0.2"
@@ -729,7 +750,7 @@ babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
 
-babel-plugin-syntax-object-rest-spread@^6.8.0:
+babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
 
@@ -1012,8 +1033,8 @@ babel-polyfill@^6.16.0:
     regenerator-runtime "^0.10.5"
 
 babel-preset-env@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.6.0.tgz#2de1c782a780a0a5d605d199c957596da43c44e4"
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.6.1.tgz#a18b564cc9b9afdf4aae57ae3c1b0d99188e6f48"
   dependencies:
     babel-plugin-check-es2015-constants "^6.22.0"
     babel-plugin-syntax-trailing-function-commas "^6.22.0"
@@ -1051,6 +1072,13 @@ babel-preset-flow@^6.23.0:
   resolved "https://registry.yarnpkg.com/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz#e71218887085ae9a24b5be4169affb599816c49d"
   dependencies:
     babel-plugin-transform-flow-strip-types "^6.22.0"
+
+babel-preset-jest@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-21.2.0.tgz#ff9d2bce08abd98e8a36d9a8a5189b9173b85638"
+  dependencies:
+    babel-plugin-jest-hoist "^21.2.0"
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
 
 babel-preset-react-hmre@^1.1.1:
   version "1.1.1"
@@ -1119,7 +1147,7 @@ babel-template@7.0.0-beta.0:
     babylon "7.0.0-beta.22"
     lodash "^4.2.0"
 
-babel-template@^6.24.1, babel-template@^6.26.0, babel-template@^6.7.0:
+babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0, babel-template@^6.7.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
   dependencies:
@@ -1143,7 +1171,7 @@ babel-traverse@7.0.0-beta.0:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-traverse@^6.23.1, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
+babel-traverse@^6.18.0, babel-traverse@^6.23.1, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
   dependencies:
@@ -1165,7 +1193,7 @@ babel-types@7.0.0-beta.0:
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1, babel-types@^6.26.0:
+babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:
@@ -1258,15 +1286,7 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@^2.10.2:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
-
-bluebird@^3.0.0, bluebird@^3.3.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
-
-bluebird@^3.4.7:
+bluebird@^3.0.0, bluebird@^3.3.0, bluebird@^3.4.7, bluebird@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
@@ -1344,8 +1364,8 @@ browser-stdout@1.3.0:
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
 
 browserify-aes@^1.0.0, browserify-aes@^1.0.4:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.0.8.tgz#c8fa3b1b7585bb7ba77c5560b60996ddec6d5309"
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.1.1.tgz#38b7ab55edb806ff2dcda1a7f1620773a477c49f"
   dependencies:
     buffer-xor "^1.0.3"
     cipher-base "^1.0.0"
@@ -1402,12 +1422,12 @@ browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6:
     caniuse-db "^1.0.30000639"
     electron-to-chromium "^1.2.7"
 
-browserslist@^2.1.2, browserslist@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.4.0.tgz#693ee93d01e66468a6348da5498e011f578f87f8"
+browserslist@^2.1.2, browserslist@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.5.1.tgz#68e4bc536bbcc6086d62843a2ffccea8396821c6"
   dependencies:
-    caniuse-lite "^1.0.30000718"
-    electron-to-chromium "^1.3.18"
+    caniuse-lite "^1.0.30000744"
+    electron-to-chromium "^1.3.24"
 
 buffer-indexof@^1.0.0:
   version "1.1.1"
@@ -1491,16 +1511,12 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000741"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000741.tgz#0be59111d4221f21f612b50ee5d67871a2c4a7a5"
+  version "1.0.30000749"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000749.tgz#556773aa3aa704f581d748fa63b46ca087aac67d"
 
-caniuse-lite@^1.0.30000718:
-  version "1.0.30000738"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000738.tgz#1820c3c9adb9a117e311a5bdca1d25bc34288eba"
-
-caniuse-lite@^1.0.30000726:
-  version "1.0.30000741"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000741.tgz#bc526bc2046e6bc38737cfd77d3026ef04b8f464"
+caniuse-lite@^1.0.30000744, caniuse-lite@^1.0.30000748:
+  version "1.0.30000749"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000749.tgz#2ff382865aead8cca35dacfbab04f58effa4c01c"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1543,8 +1559,8 @@ chalk@^1.1.3:
     supports-color "^2.0.0"
 
 chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.2.0.tgz#477b3bf2f9b8fd5ca9e429747e37f724ee7af240"
   dependencies:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
@@ -1723,10 +1739,10 @@ component-inherit@0.0.3:
   resolved "https://registry.yarnpkg.com/component-inherit/-/component-inherit-0.0.3.tgz#645fc4adf58b72b649d5cae65135619db26ff143"
 
 compressible@~2.0.11:
-  version "2.0.11"
-  resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.11.tgz#16718a75de283ed8e604041625a2064586797d8a"
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.12.tgz#c59a5c99db76767e9876500e271ef63b3493bd66"
   dependencies:
-    mime-db ">= 1.29.0 < 2"
+    mime-db ">= 1.30.0 < 2"
 
 compression@^1.5.2:
   version "1.7.1"
@@ -1753,8 +1769,8 @@ concat-stream@^1.6.0:
     typedarray "^0.0.6"
 
 connect-history-api-fallback@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.3.0.tgz#e51d17f8f0ef0db90a64fdb47de3051556e9f169"
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.4.0.tgz#3db24f973f4b923b0e82f619ce0df02411ca623d"
 
 connect@^3.6.0:
   version "3.6.5"
@@ -1787,7 +1803,7 @@ content-disposition@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
 
-content-type@~1.0.2, content-type@~1.0.4:
+content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
 
@@ -1804,16 +1820,16 @@ cookie@0.3.1, cookie@^0.3.1:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
 
 copy-webpack-plugin@^4.0.1:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-4.1.0.tgz#292a040318fe8ae3b1d7996ef05dfb483eb0b647"
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-4.2.0.tgz#252bb94597f96399d23d7fad355f8d3a661ac096"
   dependencies:
-    bluebird "^2.10.2"
-    fs-extra "^0.26.4"
-    glob "^6.0.4"
-    is-glob "^3.1.0"
+    bluebird "^3.5.1"
+    fs-extra "^4.0.2"
+    glob "^7.1.2"
+    is-glob "^4.0.0"
     loader-utils "^0.2.15"
     lodash "^4.3.0"
-    minimatch "^3.0.0"
+    minimatch "^3.0.4"
     node-dir "^0.1.10"
 
 core-js@^1.0.0:
@@ -1905,12 +1921,12 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
 
 css-color-function@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/css-color-function/-/css-color-function-1.3.0.tgz#72c767baf978f01b8a8a94f42f17ba5d22a776fc"
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/css-color-function/-/css-color-function-1.3.3.tgz#8ed24c2c0205073339fafa004bc8c141fccb282e"
   dependencies:
     balanced-match "0.1.0"
     color "^0.11.0"
-    debug "~0.7.4"
+    debug "^3.1.0"
     rgb "~0.1.0"
 
 css-color-names@0.0.4:
@@ -2076,15 +2092,11 @@ debug@2.6.9, debug@^2.2.0, debug@^2.6.6, debug@^2.6.8:
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.1:
+debug@^3.0.1, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
     ms "2.0.0"
-
-debug@~0.7.4:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-0.7.4.tgz#06e1ea8082c2cb14e39806e22e2f6f757f92af39"
 
 decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
@@ -2297,6 +2309,14 @@ domutils@1.5.1:
     dom-serializer "0"
     domelementtype "1"
 
+duplicate-package-checker-webpack-plugin@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/duplicate-package-checker-webpack-plugin/-/duplicate-package-checker-webpack-plugin-1.2.6.tgz#1366e549facc29cb946bfc27a120238b1c6cd481"
+  dependencies:
+    chalk "^1.1.3"
+    find-root "^1.0.0"
+    lodash "^4.17.4"
+
 ecc-jsbn@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
@@ -2307,13 +2327,9 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-electron-to-chromium@^1.2.7:
-  version "1.3.24"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.24.tgz#9b7b88bb05ceb9fa016a177833cc2dde388f21b6"
-
-electron-to-chromium@^1.3.18:
-  version "1.3.22"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.22.tgz#4322d52c151406e3eaef74ad02676883e8416418"
+electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.24:
+  version "1.3.27"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz#78ecb8a399066187bb374eede35d9c70565a803d"
 
 elliptic@^6.0.0:
   version "6.4.0"
@@ -2434,8 +2450,8 @@ error-stack-parser@^1.3.6:
     stackframe "^0.3.1"
 
 es-abstract@^1.7.0:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.8.2.tgz#25103263dc4decbda60e0c737ca32313518027ee"
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.9.0.tgz#690829a07cae36b222e7fd9b75c0d0573eb25227"
   dependencies:
     es-to-primitive "^1.1.1"
     function-bind "^1.1.1"
@@ -2459,24 +2475,24 @@ es3ify@^0.1.3:
     jstransform "~3.0.0"
     through "~2.3.4"
 
-es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
-  version "0.10.30"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.30.tgz#7141a16836697dbabfaaaeee41495ce29f52c939"
+es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
+  version "0.10.35"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.35.tgz#18ee858ce6a3c45c7d79e91c15fcca9ec568494f"
   dependencies:
-    es6-iterator "2"
-    es6-symbol "~3.1"
+    es6-iterator "~2.0.1"
+    es6-symbol "~3.1.1"
 
 es6-error@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.0.2.tgz#eec5c726eacef51b7f6b73c20db6e1b13b069c98"
 
-es6-iterator@2, es6-iterator@^2.0.1, es6-iterator@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.1.tgz#8e319c9f0453bf575d374940a655920e59ca5512"
+es6-iterator@^2.0.1, es6-iterator@~2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
   dependencies:
     d "1"
-    es5-ext "^0.10.14"
-    es6-symbol "^3.1"
+    es5-ext "^0.10.35"
+    es6-symbol "^3.1.1"
 
 es6-map@^0.1.3:
   version "0.1.5"
@@ -2499,7 +2515,7 @@ es6-set@~0.1.5:
     es6-symbol "3.1.1"
     event-emitter "~0.3.5"
 
-es6-symbol@3.1.1, es6-symbol@^3.1, es6-symbol@^3.1.0, es6-symbol@^3.1.1, es6-symbol@~3.1, es6-symbol@~3.1.1:
+es6-symbol@3.1.1, es6-symbol@^3.1.0, es6-symbol@^3.1.1, es6-symbol@~3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
   dependencies:
@@ -2600,8 +2616,8 @@ eslint-plugin-babel@^4.1.2:
   resolved "https://registry.yarnpkg.com/eslint-plugin-babel/-/eslint-plugin-babel-4.1.2.tgz#79202a0e35757dd92780919b2336f1fa2fe53c1e"
 
 eslint-plugin-import@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz#21de33380b9efb55f5ef6d2e210ec0e07e7fa69f"
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz#fa1b6ef31fcb3c501c09859c1b86f1fc5b986894"
   dependencies:
     builtin-modules "^1.1.1"
     contains-path "^0.1.0"
@@ -2647,8 +2663,8 @@ eslint-scope@^3.7.1:
     estraverse "^4.1.1"
 
 eslint@^4.8.0:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.8.0.tgz#229ef0e354e0e61d837c7a80fdfba825e199815e"
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.9.0.tgz#76879d274068261b191fe0f2f56c74c2f4208e8b"
   dependencies:
     ajv "^5.2.0"
     babel-code-frame "^6.22.0"
@@ -2736,7 +2752,7 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
-etag@~1.8.0, etag@~1.8.1:
+etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
 
@@ -2811,42 +2827,9 @@ expand-template@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-1.1.0.tgz#e09efba977bf98f9ee0ed25abd0c692e02aec3fc"
 
-express@^4.13.3:
-  version "4.15.5"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.15.5.tgz#670235ca9598890a5ae8170b83db722b842ed927"
-  dependencies:
-    accepts "~1.3.3"
-    array-flatten "1.1.1"
-    content-disposition "0.5.2"
-    content-type "~1.0.2"
-    cookie "0.3.1"
-    cookie-signature "1.0.6"
-    debug "2.6.9"
-    depd "~1.1.1"
-    encodeurl "~1.0.1"
-    escape-html "~1.0.3"
-    etag "~1.8.0"
-    finalhandler "~1.0.6"
-    fresh "0.5.2"
-    merge-descriptors "1.0.1"
-    methods "~1.1.2"
-    on-finished "~2.3.0"
-    parseurl "~1.3.1"
-    path-to-regexp "0.1.7"
-    proxy-addr "~1.1.5"
-    qs "6.5.0"
-    range-parser "~1.2.0"
-    send "0.15.6"
-    serve-static "1.12.6"
-    setprototypeof "1.0.3"
-    statuses "~1.3.1"
-    type-is "~1.6.15"
-    utils-merge "1.0.0"
-    vary "~1.1.1"
-
-express@^4.14.0:
-  version "4.16.1"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.16.1.tgz#6b33b560183c9b253b7b62144df33a4654ac9ed0"
+express@^4.13.3, express@^4.14.0:
+  version "4.16.2"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.16.2.tgz#e35c6dfe2d64b7dca0a5cd4f21781be3299e076c"
   dependencies:
     accepts "~1.3.4"
     array-flatten "1.1.1"
@@ -2994,7 +2977,7 @@ fill-range@^2.1.0:
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
 
-finalhandler@1.0.6, finalhandler@~1.0.6:
+finalhandler@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.0.6.tgz#007aea33d1a4d3e42017f624848ad58d212f814f"
   dependencies:
@@ -3037,6 +3020,10 @@ find-cache-dir@^1.0.0:
 find-root@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/find-root/-/find-root-0.1.2.tgz#98d2267cff1916ccaf2743b3a0eea81d79d7dcd1"
+
+find-root@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
 
 find-up@^1.0.0:
   version "1.1.2"
@@ -3094,7 +3081,7 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
-forwarded@~0.1.0, forwarded@~0.1.2:
+forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
 
@@ -3108,15 +3095,13 @@ fs-access@^1.0.0:
   dependencies:
     null-check "^1.0.0"
 
-fs-extra@^0.26.4:
-  version "0.26.7"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.26.7.tgz#9ae1fdd94897798edab76d0918cf42d0c3184fa9"
+fs-extra@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.2.tgz#f91704c53d1b461f893452b0c307d9997647ab6b"
   dependencies:
     graceful-fs "^4.1.2"
-    jsonfile "^2.1.0"
-    klaw "^1.0.0"
-    path-is-absolute "^1.0.0"
-    rimraf "^2.2.8"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -3217,16 +3202,6 @@ glob@7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^6.0.4:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
-  dependencies:
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "2 || 3"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
 glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
@@ -3274,7 +3249,7 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
+graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -3408,7 +3383,7 @@ hoist-non-react-statics@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
 
-hoist-non-react-statics@^2.2.1, hoist-non-react-statics@^2.3.0:
+hoist-non-react-statics@^2.2.1, hoist-non-react-statics@^2.3.0, hoist-non-react-statics@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
 
@@ -3441,8 +3416,8 @@ html-entities@^1.2.0:
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
 
 html-minifier@^3.2.3:
-  version "3.5.5"
-  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.5.tgz#3bdc9427e638bbe3dbde96c0eb988b044f02739e"
+  version "3.5.6"
+  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.6.tgz#7e4e661a09999599c7d8e8a2b8d7fb7430bb5c3e"
   dependencies:
     camel-case "3.0.x"
     clean-css "4.1.x"
@@ -3477,7 +3452,7 @@ http-deceiver@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/http-deceiver/-/http-deceiver-1.2.7.tgz#fa7168944ab9a519d337cb0bec7284dc3e723d87"
 
-http-errors@1.6.2, http-errors@~1.6.1, http-errors@~1.6.2:
+http-errors@1.6.2, http-errors@~1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.2.tgz#0a002cc85707192a7e7946ceedc11155f60ec736"
   dependencies:
@@ -3487,8 +3462,8 @@ http-errors@1.6.2, http-errors@~1.6.1, http-errors@~1.6.2:
     statuses ">= 1.3.1 < 2"
 
 http-parser-js@>=0.4.0:
-  version "0.4.8"
-  resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.4.8.tgz#763f75c4b771a0bb44653b07070bff6ca7bc5561"
+  version "0.4.9"
+  resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.4.9.tgz#ea1a04fb64adff0242e9974f297dd4c3cad271e1"
 
 http-proxy-middleware@~0.17.4:
   version "0.17.4"
@@ -3537,12 +3512,19 @@ ieee754@^1.1.4:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
 
 ignore@^3.3.3:
-  version "3.3.5"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.5.tgz#c4e715455f6073a8d7e5dae72d2fc9d71663dba6"
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.6.tgz#b6f3196b38ed92f0c86e52f6f79b7fc4c8266c8d"
 
 immediate@~3.0.5:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+
+import-local@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/import-local/-/import-local-0.1.1.tgz#b1179572aacdc11c6a91009fb430dbcab5f668a8"
+  dependencies:
+    pkg-dir "^2.0.0"
+    resolve-cwd "^2.0.0"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -3636,8 +3618,8 @@ intl-messageformat@^2.0.0, intl-messageformat@^2.1.0:
     intl-messageformat-parser "1.2.0"
 
 intl-relativeformat@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/intl-relativeformat/-/intl-relativeformat-2.0.0.tgz#d6ba9dc6c625819bc0abdb1d4e238138b7488f26"
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/intl-relativeformat/-/intl-relativeformat-2.1.0.tgz#010f1105802251f40ac47d0e3e1a201348a255df"
   dependencies:
     intl-messageformat "^2.0.0"
 
@@ -3654,10 +3636,6 @@ invert-kv@^1.0.0:
 ip@^1.1.0, ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
-
-ipaddr.js@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.4.0.tgz#296aca878a821816e5b85d0a285a99bcff4582f0"
 
 ipaddr.js@1.5.2:
   version "1.5.2"
@@ -3724,7 +3702,7 @@ is-extglob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
 
-is-extglob@^2.1.0:
+is-extglob@^2.1.0, is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
 
@@ -3755,6 +3733,12 @@ is-glob@^3.1.0:
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
   dependencies:
     is-extglob "^2.1.0"
+
+is-glob@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
+  dependencies:
+    is-extglob "^2.1.1"
 
 is-number@^0.1.1:
   version "0.1.1"
@@ -3891,6 +3875,22 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
+istanbul-lib-coverage@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz#73bfb998885299415c93d38a3e9adf784a77a9da"
+
+istanbul-lib-instrument@^1.7.5:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz#250b30b3531e5d3251299fdd64b0b2c9db6b558e"
+  dependencies:
+    babel-generator "^6.18.0"
+    babel-template "^6.16.0"
+    babel-traverse "^6.18.0"
+    babel-types "^6.18.0"
+    babylon "^6.18.0"
+    istanbul-lib-coverage "^1.1.1"
+    semver "^5.3.0"
+
 jquery@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"
@@ -3963,9 +3963,9 @@ json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
-jsonfile@^2.1.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -4008,11 +4008,11 @@ karma-chrome-launcher@^2.2.0:
     which "^1.2.1"
 
 karma-mocha-reporter@^2.2.3:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/karma-mocha-reporter/-/karma-mocha-reporter-2.2.4.tgz#0c9cb22c27d864d0f6694df0cf01caabce9064d4"
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/karma-mocha-reporter/-/karma-mocha-reporter-2.2.5.tgz#15120095e8ed819186e47a0b012f3cd741895560"
   dependencies:
     chalk "^2.1.0"
-    log-symbols "^2.0.0"
+    log-symbols "^2.1.0"
     strip-ansi "^4.0.0"
 
 karma-mocha@^1.3.0:
@@ -4022,8 +4022,8 @@ karma-mocha@^1.3.0:
     minimist "1.2.0"
 
 karma-webpack@^2.0.3:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/karma-webpack/-/karma-webpack-2.0.4.tgz#3e2d4f48ba94a878e1c66bb8e1ae6128987a175b"
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/karma-webpack/-/karma-webpack-2.0.5.tgz#4f56887e32cf4f9583391c2388415de06af06efd"
   dependencies:
     async "~0.9.0"
     loader-utils "^0.2.5"
@@ -4074,12 +4074,6 @@ kind-of@^4.0.0:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
   dependencies:
     is-buffer "^1.1.5"
-
-klaw@^1.0.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
-  optionalDependencies:
-    graceful-fs "^4.1.9"
 
 last-call-webpack-plugin@^2.1.2:
   version "2.1.2"
@@ -4222,8 +4216,8 @@ loader-utils@^0.2.15, loader-utils@^0.2.16, loader-utils@^0.2.5:
     object-assign "^4.0.1"
 
 localforage@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.5.0.tgz#6b994e19b56611fa85df3992df397ac4ab66e815"
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.5.2.tgz#bf873025aa0e4a827bc07c20039ae00e0ee9acae"
   dependencies:
     lie "3.0.2"
 
@@ -4380,7 +4374,7 @@ lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.16.4, l
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-log-symbols@^2.0.0:
+log-symbols@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.1.0.tgz#f35fa60e278832b538dc4dddcbb478a45d3e3be6"
   dependencies:
@@ -4394,8 +4388,8 @@ log4js@^0.6.31:
     semver "~4.3.3"
 
 loglevel@^1.4.1:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.5.0.tgz#3863984a2c326b986fbb965f378758a6dc8a4324"
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.5.1.tgz#189078c94ab9053ee215a0acdbf24244ea0f6502"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -4434,10 +4428,10 @@ macaddress@^0.2.8:
   resolved "https://registry.yarnpkg.com/macaddress/-/macaddress-0.2.8.tgz#5904dc537c39ec6dbefeae902327135fa8511f12"
 
 make-dir@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.0.0.tgz#97a011751e91dd87cfadef58832ebb04936de978"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.1.0.tgz#19b4369fe48c116f53c2af95ad102c0e39e85d51"
   dependencies:
-    pify "^2.3.0"
+    pify "^3.0.0"
 
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
@@ -4523,19 +4517,15 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-"mime-db@>= 1.29.0 < 2", mime-db@~1.30.0:
+"mime-db@>= 1.30.0 < 2", mime-db@~1.30.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
 
-mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.7:
+mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.17, mime-types@~2.1.7:
   version "2.1.17"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
   dependencies:
     mime-db "~1.30.0"
-
-mime@1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
 
 mime@1.4.1, mime@^1.2.11, mime@^1.3.4:
   version "1.4.1"
@@ -4559,7 +4549,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
 
-"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
+minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -4579,7 +4569,7 @@ minimist@~0.0.1:
 
 mirage-server@cowboyd/mirage-server:
   version "0.0.1"
-  resolved "https://codeload.github.com/cowboyd/mirage-server/tar.gz/46c8049fe08c49fa479091085a55df606b340358"
+  resolved "https://codeload.github.com/cowboyd/mirage-server/tar.gz/68a98afc1bd364e50ba13bc230ef64eb3c6d1120"
   dependencies:
     faker "^4.1.0"
     inflected "^2.0.2"
@@ -4616,8 +4606,8 @@ moment-range@^3.0.3:
     es6-symbol "^3.1.0"
 
 moment@^2.17.1:
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.1.tgz#56da1a2d1cbf01d38b7e1afc31c10bcfa1929167"
 
 mousetrap@^1.6.1:
   version "1.6.1"
@@ -4678,7 +4668,7 @@ no-case@^2.2.0:
   dependencies:
     lower-case "^1.1.1"
 
-node-abi@^2.0.0:
+node-abi@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.1.1.tgz#c9cda256ec8aa99bcab2f6446db38af143338b2a"
 
@@ -4863,8 +4853,8 @@ object-component@0.0.3:
   resolved "https://registry.yarnpkg.com/object-component/-/object-component-0.0.3.tgz#f0c69aa50efc95b866c186f400a33769cb2f1291"
 
 object-hash@^1.1.4:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.1.8.tgz#28a659cf987d96a4dabe7860289f3b5326c4a03c"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.2.0.tgz#e96af0e96981996a1d47f88ead8f74f1ebc4422b"
 
 object-keys@^1.0.6, object-keys@^1.0.8:
   version "1.0.11"
@@ -5048,7 +5038,7 @@ parseuri@0.0.5:
   dependencies:
     better-assert "~1.0.0"
 
-parseurl@~1.3.1, parseurl@~1.3.2:
+parseurl@~1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
 
@@ -5175,8 +5165,8 @@ postcss-calc@^5.2.0:
     reduce-css-calc "^1.2.6"
 
 postcss-calc@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-calc/-/postcss-calc-6.0.0.tgz#b681b279c6d24fbe0e33ed9045803705445d613b"
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-calc/-/postcss-calc-6.0.1.tgz#3d24171bbf6e7629d422a436ebfe6dd9511f4330"
   dependencies:
     css-unit-converter "^1.1.1"
     postcss "^6.0.0"
@@ -5214,11 +5204,11 @@ postcss-custom-media@^6.0.0:
     postcss "^6.0.1"
 
 postcss-custom-properties@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/postcss-custom-properties/-/postcss-custom-properties-6.1.0.tgz#9caf1151ac41b1e9e64d3a2ff9ece996ca18977d"
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-custom-properties/-/postcss-custom-properties-6.2.0.tgz#5d929a7f06e9b84e0f11334194c0ba9a30acfbe9"
   dependencies:
     balanced-match "^1.0.0"
-    postcss "^6.0.3"
+    postcss "^6.0.13"
 
 postcss-discard-comments@^2.0.4:
   version "2.0.4"
@@ -5292,11 +5282,11 @@ postcss-load-plugins@^2.3.0:
     object-assign "^4.1.0"
 
 postcss-loader@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-2.0.6.tgz#8c7e0055a3df1889abc6bad52dd45b2f41bbc6fc"
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-2.0.8.tgz#8c67ddb029407dfafe684a406cfc16bad2ce0814"
   dependencies:
     loader-utils "^1.1.0"
-    postcss "^6.0.2"
+    postcss "^6.0.0"
     postcss-load-config "^1.2.0"
     schema-utils "^0.3.0"
 
@@ -5491,31 +5481,31 @@ postcss-zindex@^2.0.1:
     uniqs "^2.0.0"
 
 postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0.14, postcss@^5.0.16, postcss@^5.0.2, postcss@^5.0.4, postcss@^5.0.5, postcss@^5.0.6, postcss@^5.0.8, postcss@^5.2.16:
-  version "5.2.17"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.17.tgz#cf4f597b864d65c8a492b2eabe9d706c879c388b"
+  version "5.2.18"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.18.tgz#badfa1497d46244f6390f58b319830d9107853c5"
   dependencies:
     chalk "^1.1.3"
     js-base64 "^2.1.9"
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
-postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.11, postcss@^6.0.2, postcss@^6.0.3:
-  version "6.0.12"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.12.tgz#6b0155089d2d212f7bd6a0cecd4c58c007403535"
+postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.11, postcss@^6.0.13, postcss@^6.0.2:
+  version "6.0.13"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.13.tgz#b9ecab4ee00c89db3ec931145bd9590bbf3f125f"
   dependencies:
     chalk "^2.1.0"
-    source-map "^0.5.7"
+    source-map "^0.6.1"
     supports-color "^4.4.0"
 
 prebuild-install@^2.1.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-2.2.2.tgz#dd47c4d61f3754fb17bbf601759e5922e16e0671"
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-2.3.0.tgz#19481247df728b854ab57b187ce234211311b485"
   dependencies:
     expand-template "^1.0.2"
     github-from-package "0.0.0"
     minimist "^1.2.0"
     mkdirp "^0.5.1"
-    node-abi "^2.0.0"
+    node-abi "^2.1.1"
     noop-logger "^0.1.1"
     npmlog "^4.0.1"
     os-homedir "^1.0.1"
@@ -5553,8 +5543,8 @@ pretty-error@^2.0.2:
     utila "~0.4"
 
 private@^0.1.6, private@^0.1.7, private@~0.1.5:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
 process-nextick-args@~1.0.6:
   version "1.0.7"
@@ -5591,13 +5581,6 @@ prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8,
     fbjs "^0.8.16"
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
-
-proxy-addr@~1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.5.tgz#71c0ee3b102de3f202f3b64f608d173fcba1a918"
-  dependencies:
-    forwarded "~0.1.0"
-    ipaddr.js "1.4.0"
 
 proxy-addr@~2.0.2:
   version "2.0.2"
@@ -5644,16 +5627,12 @@ punycode@^1.2.4, punycode@^1.4.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
 q@^1.1.2:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/q/-/q-1.5.0.tgz#dd01bac9d06d30e6f219aecb8253ee9ebdc308f1"
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
 
 qjobs@^1.1.4:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/qjobs/-/qjobs-1.1.5.tgz#659de9f2cf8dcc27a1481276f205377272382e73"
-
-qs@6.5.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.0.tgz#8d04954d364def3efc55b5a0793e1e2c8b1e6e49"
 
 qs@6.5.1:
   version "6.5.1"
@@ -5729,8 +5708,8 @@ raw-body@2.3.2:
     unpipe "1.0.0"
 
 rc@^1.1.6, rc@^1.1.7:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.1.tgz#2e03e8e42ee450b8cb3dce65be1bf8974e1dfd95"
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.2.tgz#d8ce9cb57e8d64d9c7badd9876c7c34cbe3c7077"
   dependencies:
     deep-extend "~0.4.0"
     ini "~1.3.0"
@@ -5749,7 +5728,7 @@ react-deep-force-update@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-1.1.1.tgz#bcd31478027b64b3339f108921ab520b4313dc2c"
 
-react-deep-force-update@^2.0.1:
+react-deep-force-update@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-2.1.1.tgz#8ea4263cd6455a050b37445b3f08fd839d86e909"
 
@@ -5770,15 +5749,15 @@ react-flexbox-grid@1.1.3:
     prop-types "^15.5.8"
 
 react-hot-loader@next:
-  version "3.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-3.0.0-beta.7.tgz#d5847b8165d731c4d5b30d86d5d4716227a0fa83"
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-3.0.0.tgz#6e28da9d459da8085f5ee8bdd775046ba4b5cd0b"
   dependencies:
     babel-template "^6.7.0"
     global "^4.3.0"
-    react-deep-force-update "^2.0.1"
+    react-deep-force-update "^2.1.1"
     react-proxy "^3.0.0-alpha.0"
     redbox-react "^1.3.6"
-    source-map "^0.4.4"
+    source-map "^0.6.1"
 
 react-intl@^2.3.0:
   version "2.4.0"
@@ -5799,14 +5778,14 @@ react-overlays@^0.6.12:
     warning "^3.0.0"
 
 react-overlays@^0.8.0:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.8.1.tgz#26e480003c2fd6f581a4a66c0c86cb3dff17e626"
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.8.2.tgz#ec6e2dc3e73afadca35c1be534082a473ef28177"
   dependencies:
     classnames "^2.2.5"
     dom-helpers "^3.2.1"
     prop-types "^15.5.10"
     prop-types-extra "^1.0.1"
-    react-transition-group "^2.0.0-beta.0"
+    react-transition-group "^2.2.0"
     warning "^3.0.0"
 
 react-prop-types@^0.4.0:
@@ -5862,6 +5841,13 @@ react-router@^4.0.0, react-router@^4.1.1, react-router@^4.2.0:
     prop-types "^15.5.4"
     warning "^3.0.0"
 
+react-test-renderer@^15.6.1:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.6.2.tgz#d0333434fc2c438092696ca770da5ed48037efa8"
+  dependencies:
+    fbjs "^0.8.9"
+    object-assign "^4.1.0"
+
 react-tether@0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/react-tether/-/react-tether-0.5.7.tgz#418ea61041b65b958271478489b71a3572f01422"
@@ -5880,7 +5866,7 @@ react-transform-hmr@^1.0.3:
     global "^4.3.0"
     react-proxy "^1.1.7"
 
-react-transition-group@^2.0.0-beta.0:
+react-transition-group@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.2.1.tgz#e9fb677b79e6455fd391b03823afe84849df4a10"
   dependencies:
@@ -6014,8 +6000,8 @@ reduce-css-calc@^1.2.6:
     reduce-function-call "^1.0.1"
 
 reduce-css-calc@^2.0.0:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/reduce-css-calc/-/reduce-css-calc-2.0.5.tgz#33c97838c5d4c711a5c14ef85ce4fde41483f7bd"
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/reduce-css-calc/-/reduce-css-calc-2.1.1.tgz#f4ecd7a00ec3e5683773f208067ad7da117b9db0"
   dependencies:
     css-unit-converter "^1.1.1"
     postcss-value-parser "^3.3.0"
@@ -6048,12 +6034,13 @@ redux-crud@^3.0.0:
     ramda "^0.23.0"
 
 redux-form@^7.0.3:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/redux-form/-/redux-form-7.0.4.tgz#2297b6bed40fda8bb58132e261ba0976fb4e530c"
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/redux-form/-/redux-form-7.1.1.tgz#4d9ab1d9c03beb3a8b5f8e5d0f398cff4209081f"
   dependencies:
+    babel-jest "^21.2.0"
     deep-equal "^1.0.1"
     es6-error "^4.0.0"
-    hoist-non-react-statics "^2.2.1"
+    hoist-non-react-statics "^2.3.1"
     invariant "^2.2.2"
     is-promise "^2.1.0"
     lodash "^4.17.3"
@@ -6221,9 +6208,19 @@ requires-port@1.0.x, requires-port@1.x.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
+resolve-cwd@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
+  dependencies:
+    resolve-from "^3.0.0"
+
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
+
+resolve-from@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
 
 resolve-pathname@^2.2.0:
   version "2.2.0"
@@ -6294,8 +6291,8 @@ rx@4.1.0:
   resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
 
 rxjs@^5.4.3:
-  version "5.4.3"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.4.3.tgz#0758cddee6033d68e0fd53676f0f3596ce3d483f"
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.0.tgz#26d8f3866eb700e247e0728a147c3d628993d812"
   dependencies:
     symbol-observable "^1.0.1"
 
@@ -6331,24 +6328,6 @@ semver@~4.3.3:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
 
-send@0.15.6:
-  version "0.15.6"
-  resolved "https://registry.yarnpkg.com/send/-/send-0.15.6.tgz#20f23a9c925b762ab82705fe2f9db252ace47e34"
-  dependencies:
-    debug "2.6.9"
-    depd "~1.1.1"
-    destroy "~1.0.4"
-    encodeurl "~1.0.1"
-    escape-html "~1.0.3"
-    etag "~1.8.1"
-    fresh "0.5.2"
-    http-errors "~1.6.2"
-    mime "1.3.4"
-    ms "2.0.0"
-    on-finished "~2.3.0"
-    range-parser "~1.2.0"
-    statuses "~1.3.1"
-
 send@0.16.1:
   version "0.16.1"
   resolved "https://registry.yarnpkg.com/send/-/send-0.16.1.tgz#a70e1ca21d1382c11d0d9f6231deb281080d7ab3"
@@ -6372,25 +6351,16 @@ serialize-javascript@^1.4.0:
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.4.0.tgz#7c958514db6ac2443a8abc062dc9f7886a7f6005"
 
 serve-index@^1.7.2:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/serve-index/-/serve-index-1.9.0.tgz#d2b280fc560d616ee81b48bf0fa82abed2485ce7"
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/serve-index/-/serve-index-1.9.1.tgz#d3768d69b1e7d82e5ce050fff5b453bea12a9239"
   dependencies:
-    accepts "~1.3.3"
+    accepts "~1.3.4"
     batch "0.6.1"
-    debug "2.6.8"
+    debug "2.6.9"
     escape-html "~1.0.3"
-    http-errors "~1.6.1"
-    mime-types "~2.1.15"
-    parseurl "~1.3.1"
-
-serve-static@1.12.6:
-  version "1.12.6"
-  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.12.6.tgz#b973773f63449934da54e5beba5e31d9f4211577"
-  dependencies:
-    encodeurl "~1.0.1"
-    escape-html "~1.0.3"
+    http-errors "~1.6.2"
+    mime-types "~2.1.17"
     parseurl "~1.3.2"
-    send "0.15.6"
 
 serve-static@1.13.1:
   version "1.13.1"
@@ -6571,7 +6541,7 @@ source-map@0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
-source-map@0.5.x, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.0, source-map@~0.5.1, source-map@~0.5.3:
+source-map@0.5.x, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.0, source-map@~0.5.1, source-map@~0.5.3:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
@@ -6581,7 +6551,11 @@ source-map@^0.1.38, source-map@^0.1.41:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.4.4, source-map@~0.4.1:
+source-map@^0.6.1, source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+
+source-map@~0.4.1:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
   dependencies:
@@ -6652,7 +6626,11 @@ stackframe@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-0.3.1.tgz#33aa84f1177a5548c8935533cbfeb3420975f5a4"
 
-"statuses@>= 1.3.1 < 2", statuses@~1.3.1:
+"statuses@>= 1.3.1 < 2":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
+
+statuses@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
 
@@ -6766,8 +6744,8 @@ supports-color@^3.2.3:
     has-flag "^1.0.0"
 
 supports-color@^4.0.0, supports-color@^4.2.1, supports-color@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.4.0.tgz#883f7ddabc165142b2a61427f3352ded195d1a3e"
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
   dependencies:
     has-flag "^2.0.0"
 
@@ -6818,8 +6796,8 @@ tapable@^0.2.7:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.2.8.tgz#99372a5c999bf2df160afc0d74bed4f47948cd22"
 
 tar-fs@^1.13.0:
-  version "1.15.3"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-1.15.3.tgz#eccf935e941493d8151028e636e51ce4c3ca7f20"
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-1.16.0.tgz#e877a25acbcc51d8c790da1c57c9cf439817b896"
   dependencies:
     chownr "^1.0.1"
     mkdirp "^0.5.1"
@@ -6855,6 +6833,16 @@ tar@^2.2.1:
     block-stream "*"
     fstream "^1.0.2"
     inherits "2"
+
+test-exclude@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.1.1.tgz#4d84964b0966b0087ecc334a2ce002d3d9341e26"
+  dependencies:
+    arrify "^1.0.1"
+    micromatch "^2.3.11"
+    object-assign "^4.1.0"
+    read-pkg-up "^1.0.1"
+    require-main-filename "^1.0.1"
 
 tether@^1.3.7:
   version "1.4.0"
@@ -6985,15 +6973,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
 ua-parser-js@^0.7.9:
-  version "0.7.14"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.14.tgz#110d53fa4c3f326c121292bbeac904d2e03387ca"
+  version "0.7.17"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
 
 uglify-js@3.1.x:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.1.3.tgz#d61f0453b4718cab01581f3162aa90bab7520b42"
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.1.5.tgz#4c1a6d53b2fe77e4710dd94631853effd3ff5143"
   dependencies:
     commander "~2.11.0"
-    source-map "~0.5.1"
+    source-map "~0.6.1"
 
 uglify-js@^2.8.29:
   version "2.8.29"
@@ -7048,6 +7036,10 @@ universal-cookie@^2.1.0:
   dependencies:
     cookie "^0.3.1"
     object-assign "^4.1.0"
+
+universalify@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
@@ -7119,10 +7111,6 @@ utila@~0.4:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
 
-utils-merge@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.0.tgz#0294fb922bb9375153541c4f7096231f287c8af8"
-
 utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
@@ -7146,7 +7134,7 @@ value-equal@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
 
-vary@~1.1.1, vary@~1.1.2:
+vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
 
@@ -7210,8 +7198,8 @@ webpack-dev-middleware@^1.0.11, webpack-dev-middleware@^1.10.0, webpack-dev-midd
     time-stamp "^2.0.0"
 
 webpack-dev-server@^2.5.0:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-2.9.1.tgz#7ac9320b61b00eb65b2109f15c82747fc5b93585"
+  version "2.9.3"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-2.9.3.tgz#f0554e88d129e87796a6f74a016b991743ca6f81"
   dependencies:
     ansi-html "0.0.7"
     array-includes "^3.0.3"
@@ -7219,10 +7207,12 @@ webpack-dev-server@^2.5.0:
     chokidar "^1.6.0"
     compression "^1.5.2"
     connect-history-api-fallback "^1.3.0"
+    debug "^3.1.0"
     del "^3.0.0"
     express "^4.13.3"
     html-entities "^1.2.0"
     http-proxy-middleware "~0.17.4"
+    import-local "^0.1.1"
     internal-ip "1.2.0"
     ip "^1.1.5"
     loglevel "^1.4.1"
@@ -7239,8 +7229,8 @@ webpack-dev-server@^2.5.0:
     yargs "^6.6.0"
 
 webpack-hot-middleware@^2.16.1:
-  version "2.19.1"
-  resolved "https://registry.yarnpkg.com/webpack-hot-middleware/-/webpack-hot-middleware-2.19.1.tgz#5db32c31c955c1ead114d37c7519ea554da0d405"
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/webpack-hot-middleware/-/webpack-hot-middleware-2.20.0.tgz#cb896d837758b6408fe0afeeafdc0e5316b15319"
   dependencies:
     ansi-html "0.0.7"
     html-entities "^1.2.0"
@@ -7261,8 +7251,8 @@ webpack-virtual-modules@^0.1.8:
     debug "^2.6.8"
 
 webpack@^3.0.0, webpack@^3.4.1:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.6.0.tgz#a89a929fbee205d35a4fa2cc487be9cbec8898bc"
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.8.1.tgz#b16968a81100abe61608b0153c9159ef8bb2bd83"
   dependencies:
     acorn "^5.0.0"
     acorn-dynamic-import "^2.0.0"


### PR DESCRIPTION
As it stood, the value for the RMAPI customer ID and API key were per
deployment. Now however, it can be configured via the
/eholdings/configuration endpoint so that each tenant can maintain
their own set of credentials. We needed a way to detect if the
eholdings app is usable, and if its backend is configured
correctly, and also to be able to change credentials.

This change checks on every eholdings application entry to see if
infact there _is_ a  backend for eholdings and gives you instruction
on how to download it. If there is a backend, it will ensure that it
is configured properly, and if not, it will direct the user to a new
settings screen with which a tenant admin can view the current
configuration and make changes where necessary.

In order to support development against server configurations which
are hard to arrive at (such as a borked backend) the ability to start
the app in different scenarios was added. For example to start the app
without a backend, you would invoke the command:

```
yarn start --mirage no-backend
```

## Screenshots

![2017-10-23 16 58 57](https://user-images.githubusercontent.com/4205/31915622-bfd0de8a-b814-11e7-898e-5e834cd84bbb.gif)

![2017-10-23 17 09 45](https://user-images.githubusercontent.com/4205/31915706-12417c60-b815-11e7-97b8-ba7aa07f667d.gif)

![2017-10-23 17 05 11](https://user-images.githubusercontent.com/4205/31915637-cfcd2212-b814-11e7-98c7-96a7c6613d88.gif)


