### PR TITLE
Clean up mirage headers

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -13,37 +13,30 @@ export default function () {
   // e-holdings endpoints
   this.namespace = 'eholdings';
 
-  // fetch polyfill needs this header set so it can reliably set `response.url`
-  const getHeaders = (req) => ({ 'X-Request-URL': req.url });
-
   // Package resources
   this.get('/packages', ({ packages }, request) => {
-    const filteredPackages = packages.all().filter((packageModel) => {
+    return packages.all().filter((packageModel) => {
       const query = request.queryParams.search.toLowerCase();
       return packageModel.packageName.toLowerCase().includes(query);
     });
-
-    return new Response(200, getHeaders(request), filteredPackages);
   });
 
   this.get('/vendors/:vendorId/packages/:packageId', ({ packages }, request) => {
-    const vendorPackage = packages.findBy({
+    return packages.findBy({
       vendorId: request.params.vendorId,
       id: request.params.packageId
     });
-
-    return new Response(200, getHeaders(request), vendorPackage);
   });
 
   this.get('/vendors/:vendorId/packages/:packageId/titles', ({ customerResources }, request) => {
-    return new Response(200, getHeaders(request), customerResources.where({ packageId: request.params.packageId }));
+    return customerResources.where({ packageId: request.params.packageId });
   });
 
   this.get('/vendors/:vendorId/packages/:packageId/titles/:titleId', ({ customerResources }, request) => {
-    return new Response(200, getHeaders(request), customerResources.findBy({
+    return customerResources.findBy({
       packageId: request.params.packageId,
       titleId: request.params.titleId
-    }));
+    });
   });
 
   this.put('/vendors/:vendorId/packages/:packageId/titles/:titleId', ({ customerResources, titles }, request) => {
@@ -54,45 +47,35 @@ export default function () {
 
     let { isSelected } = JSON.parse(request.requestBody);
     matchingCustomerResource.update('isSelected', isSelected).save();
-
-    return new Response(200, getHeaders(request), '');
   });
 
   // Title resources
   this.get('/titles', ({ titles }, request) => {
-    const filteredTitles = titles.all().filter((titleModel) => {
+    return titles.all().filter((titleModel) => {
       const query = request.queryParams.search.toLowerCase();
       return titleModel.titleName.toLowerCase().includes(query);
     });
-
-    return new Response(200, getHeaders(request), filteredTitles);
   });
 
   this.get('/titles/:id', ({ titles }, request) => {
-    const title = titles.find(request.params.id);
-    return new Response(200, getHeaders(request), title);
+    return titles.find(request.params.id);
   });
 
   // Vendor resources
   this.get('/vendors', ({ vendors }, request) => {
-    const filteredVendors = vendors.all().filter((vendorModel) => {
-      const query = request.queryParams.search.toLowerCase();
+    return vendors.all().filter((vendorModel) => {
+      let query = request.queryParams.search.toLowerCase();
       return vendorModel.vendorName.toLowerCase().includes(query);
     });
-
-    return new Response(200, getHeaders(request), filteredVendors);
   });
 
   this.get('/vendors/:id', ({ vendors }, request) => {
-    const vendor = vendors.find(request.params.id);
-    return new Response(200, getHeaders(request), vendor);
+    return vendors.find(request.params.id);
   });
 
   this.get('/vendors/:vendorId/packages', ({ packages }, request) => {
-    const vendorPackages =  packages.where( { vendorId: request.params.vendorId } );
-    return new Response(200, getHeaders(request), vendorPackages);
+    return packages.where({ vendorId: request.params.vendorId });
   });
-
 
   // hot-reload passthrough
   this.pretender.get('/:rand.hot-update.json', this.pretender.passthrough);


### PR DESCRIPTION
Previously, stripes-connect required `response.url` to be present on the response. The fetch polyfill used with mirage does not set this property unless the response headers include `X-Request-URL`.

Now that stripes-connect usage has been removed from our app, it is safe to clean up these extraneous headers from the config.