### PR TITLE
Rework search layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "webpack-dev-server": "^2.5.0"
   },
   "dependencies": {
+    "classnames": "^2.2.5",
     "isomorphic-fetch": "^2.2.1",
     "redux-actions": "^2.2.1"
   },

--- a/src/components/list/list.css
+++ b/src/components/list/list.css
@@ -1,5 +1,5 @@
 .list {
-  margin: 1rem 0;
+  margin: 0;
   padding: 0;
 
   & li {
@@ -7,8 +7,8 @@
     list-style-type: none;
     margin: 0;
 
-    &:first-child {
-      border-top: 1px solid #dcdcdc;
+    &:last-child {
+      border-bottom: none;
     }
 
     & a {

--- a/src/components/results-pane/index.js
+++ b/src/components/results-pane/index.js
@@ -1,0 +1,1 @@
+export { default } from './results-pane';

--- a/src/components/results-pane/results-pane.css
+++ b/src/components/results-pane/results-pane.css
@@ -1,0 +1,9 @@
+.results-pane {
+  display: flex;
+  flex: 1 0 0;
+  flex-flow: column nowrap;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+  z-index: 10;
+}

--- a/src/components/results-pane/results-pane.js
+++ b/src/components/results-pane/results-pane.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './results-pane.css';
+
+export default class ResultsPane extends React.Component {
+  static propTypes = {
+    children: PropTypes.node
+  }
+
+  render() {
+    return (
+      <div className={styles['results-pane']}>
+        {this.props.children}
+      </div>
+    );
+  }
+}

--- a/src/components/search-form/search-form.css
+++ b/src/components/search-form/search-form.css
@@ -1,13 +1,12 @@
 @import '@folio/stripes-core/src/components/variables';
 
 .search-form-container {
-  margin: 1em 0 0.5em 0;
-  width: 100%;
+  padding: 1em;
 }
 
 .search-switcher {
-  float: left;
   margin: 0 1em;
+  width: 100%;
 
   & a {
     display: inline-block;

--- a/src/components/search-form/search-form.css
+++ b/src/components/search-form/search-form.css
@@ -68,7 +68,17 @@
 }
 
 .search-submit {
-  display: none;
+  background-color: var(--primary);
+  border: 1px solid var(--primary);
+  border-radius: 0.4em;
+  color: #fff;
+  line-height: 2em;
+  margin-top: 1em;
+  width: 100%;
+
+  &:hover{
+    background-color: color(var(--primary) shade(8%));
+  }
 }
 
 .search-results-list {

--- a/src/components/search-form/search-form.css
+++ b/src/components/search-form/search-form.css
@@ -5,51 +5,70 @@
 }
 
 .search-switcher {
-  margin: 0 1em;
+  display: block;
+  margin: 0 auto 1em auto;
+  position: relative;
+  vertical-align: middle;
   width: 100%;
 
   & a {
-    display: inline-block;
     border: 1px solid var(--primary);
-    border-width: 1px 1px 1px 0;
+    border-radius: 0.4em;
+    display: inline-block;
+    flex: 0 1 auto;
     padding: 0.36em 0.57em;
+    position: relative;
+    text-align: center;
+    user-select: none;
     text-decoration: none;
-    line-height: 1;
+    vertical-align: middle;
+    white-space: nowrap;
+    width: calc(100% / 3);
 
     &:first-child {
-      border-left-width: 1px;
-      border-radius: 0.4em 0 0 0.4em;
+      margin-left: 0;
+
+      &:not(:last-child) {
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+      }
     }
 
-    &:last-child {
-      border-radius: 0 0.4em 0.4em 0;
+    &:last-child:not(:first-child) {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
     }
 
     &.is-active {
       background-color: var(--primary);
       color: #fff;
     }
+
+    &:not(:first-child):not(:last-child) {
+      border-radius: 0;
+    }
+  }
+
+  & a + a {
+    margin-left: -1px;
   }
 }
 
 .search-input {
-  height: var(--controlHeight);
-  min-height: var(--controlHeight);
-  margin-bottom: var(--controlMarginBottom);
-  padding: 4px;
-  border: 1px solid var(--inputBorderColor);
+  box-sizing: border-box;
+  border: 2px solid #ccc;
+  border-radius: 2px;
+  font-size: 13px;
+  background-color: #fff;
+  background-position: 10px 10px;
+  background-repeat: no-repeat;
+  padding: 5px;
+  border-radius: 5px;
+  width: 100%;
 }
 
 .search-submit {
-  margin-left: 0.5em;
-  background-color: var(--primary);
-  border: 1px solid var(--primary);
-  border-radius: 0.4em;
-  color: #fff;
-
-  &:hover{
-    background-color: color(var(--primary) shade(8%));
-  }
+  display: none;
 }
 
 .search-results-list {

--- a/src/components/search-form/search-form.js
+++ b/src/components/search-form/search-form.js
@@ -58,7 +58,7 @@ export default class SearchForm extends Component {
               type="search"
               name="search"
               value={searchString}
-              placeholder={`Search for ${searchType}`}
+              placeholder={`Search for ${searchType}...`}
               onChange={this.handleChangeSearch}
               data-test-search-field />
           <button

--- a/src/components/search-pane-vignette/index.js
+++ b/src/components/search-pane-vignette/index.js
@@ -1,0 +1,1 @@
+export { default } from './search-pane-vignette';

--- a/src/components/search-pane-vignette/search-pane-vignette.css
+++ b/src/components/search-pane-vignette/search-pane-vignette.css
@@ -1,0 +1,14 @@
+.search-pane-vignette {
+  height: 100%;
+  z-index: 11;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: rgba(0,0,0,.1);
+
+  &.is-hidden {
+    display: none;
+  }
+}

--- a/src/components/search-pane-vignette/search-pane-vignette.js
+++ b/src/components/search-pane-vignette/search-pane-vignette.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './search-pane-vignette.css';
+import classNames from 'classnames/bind';
+
+const cx = classNames.bind(styles);
+
+export default class SearchPaneVignette extends React.Component {
+  static propTypes = {
+    isHidden: PropTypes.bool,
+    onClick: PropTypes.func
+  }
+
+  render() {
+    return (
+      <div onClick={this.props.onClick} className={cx('search-pane-vignette', {
+        'is-hidden': this.props.isHidden
+      })}>
+      </div>
+    );
+  }
+}

--- a/src/components/search-pane/index.js
+++ b/src/components/search-pane/index.js
@@ -1,0 +1,1 @@
+export { default } from './search-pane';

--- a/src/components/search-pane/search-pane.css
+++ b/src/components/search-pane/search-pane.css
@@ -1,0 +1,31 @@
+.search-pane {
+  background: #fff;
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: 12;
+
+  &.is-hidden {
+    display: none;
+  }
+}
+
+@media(min-width: 641px){
+  .search-pane {
+    width: 320px;
+  }
+}
+
+@media(min-width: 961px){
+  .search-pane,
+  .search-pane.is-hidden {
+    border-right: 1px solid rgba(0,0,0,.2);
+    display: flex;
+    flex: 0 0 320px;
+    flex-flow: column nowrap;
+    overflow: hidden;
+    position: relative;
+  }
+}

--- a/src/components/search-pane/search-pane.js
+++ b/src/components/search-pane/search-pane.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './search-pane.css';
+import classNames from 'classnames/bind';
+
+const cx = classNames.bind(styles);
+
+export default class SearchPane extends React.Component {
+  static propTypes = {
+    children: PropTypes.node,
+    isHidden: PropTypes.bool
+  }
+
+  render() {
+    return (
+      <div className={cx('search-pane', {
+        'is-hidden': this.props.isHidden
+      })}>
+        {this.props.children}
+      </div>
+    );
+  }
+}

--- a/src/components/search-paneset/index.js
+++ b/src/components/search-paneset/index.js
@@ -1,0 +1,1 @@
+export { default } from './search-paneset';

--- a/src/components/search-paneset/search-paneset.css
+++ b/src/components/search-paneset/search-paneset.css
@@ -1,0 +1,24 @@
+.search-paneset {
+  height: calc(100vh - 44px);
+  position: relative;
+}
+
+@media(min-width: 961px){
+  .search-paneset {
+    align-items: flex-start;
+    display: flex;
+    flex: 0 1 auto;
+    flex-flow: row nowrap;
+    justify-content: flex-start;
+  }
+
+  .search-pane-toggle,
+  .results-pane-search-toggle {
+    display: none;
+  }
+}
+
+.scrollable-container {
+  height: calc(100vh - 88px);
+  overflow-y: scroll;
+}

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import PaneHeader from '@folio/stripes-components/lib/PaneHeader';
+import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
+import capitalize from 'lodash/capitalize';
+
+import SearchPane from '../search-pane';
+import ResultsPane from '../results-pane';
+import SearchPaneVignette from '../search-pane-vignette';
+
+import styles from './search-paneset.css';
+
+export default class SearchPaneset extends React.Component {
+  static propTypes = {
+    children: PropTypes.node,
+    searchForm: PropTypes.node,
+    hideFilters: PropTypes.bool,
+    hasResults: PropTypes.bool,
+    resultsType: PropTypes.string
+  }
+
+  state = {
+    hideFilters: this.props.hideFilters
+  };
+
+  componentWillReceiveProps({ hideFilters }) {
+    if (hideFilters !== this.state.hideFilters) {
+      this.setState({ hideFilters });
+    }
+  }
+
+  toggleFilters = () => {
+    this.setState(({ hideFilters }) => ({
+      hideFilters: !hideFilters
+    }));
+  };
+
+  render() {
+    let { searchForm, hasResults, resultsType, children } = this.props;
+
+    return (
+      <div className={styles['search-paneset']}>
+        <SearchPaneVignette isHidden={this.state.hideFilters} onClick={this.toggleFilters} />
+        <SearchPane isHidden={this.state.hideFilters}>
+          <PaneHeader
+            lastMenu={hasResults && (
+              <PaneMenu><button onClick={this.toggleFilters} className={styles['search-pane-toggle']}>Apply</button></PaneMenu>
+            )}
+          />
+          <div className={styles['scrollable-container']}>
+            {searchForm}
+          </div>
+        </SearchPane>
+        {hasResults && (
+          <ResultsPane>
+            <PaneHeader
+              paneTitle={capitalize(resultsType)}
+              firstMenu={(
+                <PaneMenu><button onClick={this.toggleFilters} className={styles['results-pane-search-toggle']}>&larr; Search</button></PaneMenu>
+              )}
+            />
+            <div className={styles['scrollable-container']}>
+              {children}
+            </div>
+          </ResultsPane>
+        )}
+      </div>
+    );
+  }
+}

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -40,7 +40,9 @@ export default class SearchPaneset extends React.Component {
 
     return (
       <div className={styles['search-paneset']}>
-        <SearchPaneVignette isHidden={this.state.hideFilters} onClick={this.toggleFilters} />
+        {hasResults && (
+          <SearchPaneVignette isHidden={this.state.hideFilters} onClick={this.toggleFilters} />
+        )}
         <SearchPane isHidden={this.state.hideFilters}>
           <PaneHeader
             lastMenu={hasResults ? (

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -43,8 +43,10 @@ export default class SearchPaneset extends React.Component {
         <SearchPaneVignette isHidden={this.state.hideFilters} onClick={this.toggleFilters} />
         <SearchPane isHidden={this.state.hideFilters}>
           <PaneHeader
-            lastMenu={hasResults && (
+            lastMenu={hasResults ? (
               <PaneMenu><button onClick={this.toggleFilters} className={styles['search-pane-toggle']}>Apply</button></PaneMenu>
+            ) : (
+              <span></span>
             )}
           />
           <div className={styles['scrollable-container']}>

--- a/src/redux/request.js
+++ b/src/redux/request.js
@@ -11,6 +11,7 @@ import 'rxjs/add/operator/catch';
 export const REQUEST_MAKE = '@@ui-eholdings/REQUEST_MAKE';
 export const REQUEST_RESOLVE = '@@ui-eholdings/REQUEST_RESOLVE';
 export const REQUEST_REJECT = '@@ui-eholdings/REQUEST_REJECT';
+export const REQUEST_CLEAR = '@@ui-eholdings/REQUEST_CLEAR';
 
 /**
  * Creates an action creator to start a request for a specific named epic
@@ -32,6 +33,13 @@ export function createRequestCreator(name, options = {}) {
     name,
     options,
     data
+  });
+}
+
+export function createClearRequestCreator(name) {
+  return () => ({
+    type: REQUEST_CLEAR,
+    name
   });
 }
 
@@ -169,6 +177,10 @@ export function createRequestReducer({
       isPending: false,
       isRejected: true,
       error
+    }),
+    [REQUEST_CLEAR]: (state) => ({
+      ...state,
+      ...defaultState
     })
   }, initialState);
 

--- a/src/redux/search.js
+++ b/src/redux/search.js
@@ -3,6 +3,7 @@ import { combineEpics } from 'redux-observable';
 import {
   REQUEST_MAKE,
   createRequestCreator,
+  createClearRequestCreator,
   createRequestReducer,
   createRequestEpic
 } from './request';
@@ -11,6 +12,9 @@ import {
 export const searchVendors = createRequestCreator('vendors-search');
 export const searchPackages = createRequestCreator('packages-search');
 export const searchTitles = createRequestCreator('titles-search');
+export const clearVendors = createClearRequestCreator('vendors-search');
+export const clearPackages = createClearRequestCreator('packages-search');
+export const clearTitles = createClearRequestCreator('titles-search');
 
 // search specific reducer creator
 function createSearchReducer(name) {


### PR DESCRIPTION
Now responsive with two panes. In the middle range the search pane will pop out with a vignette behind it.

Biggest size:
![localhost-3000-eholdings-search-packages-search e ipad](https://user-images.githubusercontent.com/230597/30936854-bafb30ce-a39a-11e7-9f22-72d6d5191eb0.png)

Middle size:
![localhost-3000-eholdings-search-packages-search e ipad 1](https://user-images.githubusercontent.com/230597/30936944-0419254a-a39b-11e7-98f0-ca7de99afbac.png)

Smallest size:
![localhost-3000-eholdings-search-packages-search e iphone 5](https://user-images.githubusercontent.com/230597/30936948-09b05e88-a39b-11e7-84ed-d9816fb391c1.png)

