### PR TITLE
Fix frontpage mobile styles

### DIFF
--- a/demo/front.css
+++ b/demo/front.css
@@ -1,7 +1,9 @@
 .front {
-  margin: 3em auto;
+  height: calc(100vh - 44px);
+  margin: 0 auto;
   max-width: 50em;
-  padding: 0 2em;
+  overflow: auto;
+  padding: 3em 2em 0;
 }
 
 .logo {


### PR DESCRIPTION
Making sure the nav bar is visible and having contained apps scroll underneath it seems like it should be part of `stripes-core`. However there is currently no such enforcements in place (as there is no comprehensive responsive styles in most of stripes).

App's typically use `Pane` and `Paneset` components to render their content, and these components _do_ take the header height into account in their styling. However, our `front` component does not use a `Pane`, and so we need to ensure that the header height is taking into account ourselves. 

### Before

![before](https://user-images.githubusercontent.com/5005153/31193222-1e5ec518-a909-11e7-813d-bbed8b20e42b.gif)

### After

![after](https://user-images.githubusercontent.com/5005153/31193228-22c36564-a909-11e7-89c5-d279a1c1ea02.gif)
