### PR TITLE
Hide search pane vignette at large sizes

### DIFF
--- a/src/components/search-pane-vignette/search-pane-vignette.css
+++ b/src/components/search-pane-vignette/search-pane-vignette.css
@@ -12,3 +12,9 @@
     display: none;
   }
 }
+
+@media(min-width: 961px){
+  .search-pane-vignette {
+    display: none;
+  }
+}


### PR DESCRIPTION
If the browser window was resized, the search pane vignette (the partially transparent background between the search form and the results) was still showing up. It should never appear above the largest breakpoint.