### PR TITLE
Change webpack config for css

### DIFF
--- a/demo/stripes.js
+++ b/demo/stripes.js
@@ -11,8 +11,6 @@ const webpackHotMiddleware = require('webpack-hot-middleware');
 const connectHistoryApiFallback = require('connect-history-api-fallback');
 
 const StripesConfigPlugin = require('@folio/stripes-core/webpack/stripes-config-plugin');
-const devConfig = require('@folio/stripes-core/webpack.config.cli.dev');
-const prodConfig = require('@folio/stripes-core/webpack.config.cli.prod');
 
 const stripesCorePath = path.dirname(require.resolve('@folio/stripes-core/index.html'));
 const cwd = path.resolve();
@@ -26,11 +24,11 @@ commander.version(packageJSON.version);
 const cachePlugin = new HardSourceWebpackPlugin({
   cacheDirectory: path.join(cwd, 'webpackcache'),
   recordsPath: path.join(cwd, 'webpackcache/records.json'),
-  configHash() {
+  configHash(webpackConfig) {
     // Build a string value used by HardSource to determine which cache to
     // use if [confighash] is in cacheDirectory or if the cache should be
     // replaced if [confighash] does not appear in cacheDirectory.
-    return nodeObjectHash().hash(devConfig);
+    return nodeObjectHash().hash(webpackConfig);
   }
 });
 
@@ -95,7 +93,7 @@ commander
   .description('Launch a webpack-dev-server')
   .action((stripesConfigFile, options) => {
     const app = express();
-
+    const devConfig = require('@folio/stripes-core/webpack.config.cli.dev'); // eslint-disable-line
     const config = Object.assign({}, devConfig);
     const stripesConfig = require(path.resolve(stripesConfigFile)); // eslint-disable-line
     config.plugins.push(new StripesConfigPlugin(stripesConfig));
@@ -152,6 +150,7 @@ commander
   .arguments('<config> <output>')
   .description('Build a tenant bundle')
   .action((stripesConfigFile, outputPath, options) => {
+    const prodConfig = require('@folio/stripes-core/webpack.config.cli.prod'); // eslint-disable-line
     const config = Object.assign({}, prodConfig);
     const stripesConfig = require(path.resolve(stripesConfigFile)); // eslint-disable-line
     config.plugins.push(new StripesConfigPlugin(stripesConfig));

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint ./"
   },
   "devDependencies": {
-    "@folio/stripes-core": "thefrontside/stripes-core#master",
+    "@folio/stripes-core": "thefrontside/stripes-core#jc/webpack-css",
     "babel-core": "^6.25.0",
     "babel-eslint": "^8.0.1",
     "babel-loader": "^7.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,9 +39,9 @@
     redux-crud "^3.0.0"
     uuid "^3.0.1"
 
-"@folio/stripes-core@thefrontside/stripes-core#master":
+"@folio/stripes-core@thefrontside/stripes-core#jc/webpack-css":
   version "2.7.0"
-  resolved "https://codeload.github.com/thefrontside/stripes-core/tar.gz/5cc150f1339d3dcc50ae04dd737e2f92ef4a4b86"
+  resolved "https://codeload.github.com/thefrontside/stripes-core/tar.gz/d145cd5d70898fbc952ed3503540deb6fded81a4"
   dependencies:
     "@folio/stripes-components" "^1.6.0"
     "@folio/stripes-connect" folio-org/stripes-connect#3c2714a189c2296f389fc6ee4e79a7ee7c962949
@@ -71,6 +71,7 @@
     localforage "^1.5.0"
     lodash "^4.16.4"
     node-object-hash "^1.2.0"
+    optimize-css-assets-webpack-plugin "^3.2.0"
     postcss "^6.0.2"
     postcss-calc "^6.0.0"
     postcss-color-function "^4.0.0"
@@ -1973,7 +1974,7 @@ cssesc@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-0.1.0.tgz#c814903e45623371a0477b40109aaafbeeaddbb4"
 
-"cssnano@>=2.6.1 <4":
+"cssnano@>=2.6.1 <4", cssnano@^3.4.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-3.10.0.tgz#4f38f6cea2b9b17fa01490f23f1dc68ea65c1c38"
   dependencies:
@@ -4080,6 +4081,13 @@ klaw@^1.0.0:
   optionalDependencies:
     graceful-fs "^4.1.9"
 
+last-call-webpack-plugin@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/last-call-webpack-plugin/-/last-call-webpack-plugin-2.1.2.tgz#ad80c6e310998294d2ed2180a68e9589e4768c44"
+  dependencies:
+    lodash "^4.17.4"
+    webpack-sources "^1.0.1"
+
 lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
@@ -4907,6 +4915,13 @@ optimist@^0.6.1:
   dependencies:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
+
+optimize-css-assets-webpack-plugin@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-3.2.0.tgz#09a40c4cefde1dd0142444a873c56aa29eb18e6f"
+  dependencies:
+    cssnano "^3.4.0"
+    last-call-webpack-plugin "^2.1.2"
 
 optionator@^0.8.2:
   version "0.8.2"


### PR DESCRIPTION
Uses `stripes-core` fork branch to appropriately build css for production.

This will basically be a test deploy. If successful, I'll be opening a PR on `stripes-core` upstream to match the changes on the fork, then opening another PR here to go back to `stripes-core` master later.

Related to https://issues.folio.org/browse/UIEH-88