### PR TITLE
Adjust to Okapi now needing login

### DIFF
--- a/demo/stripes.config.js
+++ b/demo/stripes.config.js
@@ -2,7 +2,6 @@ module.exports = {
   okapi: { url: 'https://okapi.frontside.io', tenant: 'fs' },
   config: {
     hasAllPerms: true,
-    disableAuth: true,
     logCategories: ''
   },
   modules: {

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -1,5 +1,5 @@
 import { okapi } from 'stripes-config'; // eslint-disable-line import/no-unresolved
-/* import { Response } from 'mirage-server'; */
+import { Response } from 'mirage-server';
 
 export default function () {
   // Okapi configs
@@ -8,6 +8,38 @@ export default function () {
   this.get('/_/proxy/modules', []);
   this.get('/saml/check', {
     ssoEnabled: false
+  });
+
+  // mod-users
+  this.get('/users', []);
+
+  // mod-config
+  this.get('/configurations/entries', {
+    configs: []
+  });
+
+  // mod-users-bl
+  this.post('/bl-users/login', () => {
+    let okapiTokenHeader = () => {
+      return { 'X-Okapi-Token': `myOkapiToken:${Date.now()}` };
+    };
+
+    return new Response(201,
+      okapiTokenHeader(),
+      {
+        user: {
+          username: 'testuser',
+          personal: {
+            lastName: 'User',
+            firstName: 'Test',
+            email: 'folio_admin@frontside.io',
+          }
+        },
+        permissions: {
+          permissions: []
+        }
+      }
+    );
   });
 
   // e-holdings endpoints


### PR DESCRIPTION
## Purpose
`disableAuth` is no longer available as a `stripes` config option.

## Approach
This creates the endpoints needed for `mirage` to mock a login against an actual Okapi instance.

## Learning
There's an `autoLogin` option in `stripes` configs that we should explore: https://github.com/folio-org/stripes-core/blob/a0ed2792a3cfc497191aa769258c921e1015bbd8/src/components/Login/LoginCtrl.js#L34

In my quick try of it, the login screen would confusingly appear before the session authenticated, which I found pretty not great. There should be a loading animation instead that prevents the login screen from ever appearing if `autoLogin` is set.

## Screenshots
![fiewfj22ub](https://user-images.githubusercontent.com/230597/31798111-8d1c95e4-b4f7-11e7-97fc-69c265edd35f.gif)
