### PR TITLE
Add Okapi token to request headers

### DIFF
--- a/src/redux/request.js
+++ b/src/redux/request.js
@@ -266,9 +266,12 @@ export function createRequestEpic({
       .switchMap(({ data = {}, options = {} }) => {
         let { okapi } = getState();
         let { method = 'GET' } = options;
-        let body;
-        let headers = { 'X-Okapi-Tenant': okapi.tenant };
         let url = endpoint;
+        let headers = {
+          'X-Okapi-Tenant': okapi.tenant,
+          'X-Okapi-Token': okapi.token
+        };
+        let body;
 
         // endpoint url
         if (typeof endpoint === 'function') {
@@ -279,7 +282,7 @@ export function createRequestEpic({
 
         // request body
         if (method === 'PUT' || method === 'POST') {
-          headers['Content-Type'] = 'application/json';
+          headers['Content-Type'] = 'application/vnd.api+json';
           body = JSON.stringify(serialize(data));
 
         // query params


### PR DESCRIPTION
## Purpose
Currently, any request we make from the UI does not include our user's token. So the server complains about permissions or missing tokens with any request. This adds that token to the request headers that are created using the request epic.

## Approach
Adds the Okapi token to request headers
Also change Content-Type to be JSON API compliant
