### PR TITLE
Fix triggering a search when switching search types

### DIFF
--- a/src/components/search-form/search-form.js
+++ b/src/components/search-form/search-form.js
@@ -40,7 +40,7 @@ export default class SearchForm extends Component {
     const { searchString } = this.state;
 
     return (
-      <div className={styles['search-form-container']}>
+      <div className={styles['search-form-container']} data-test-search-form={searchType}>
         <div className={styles['search-switcher']}>
           {Object.keys(searchTypeLocations).map(type => (
             <NavLink
@@ -48,6 +48,7 @@ export default class SearchForm extends Component {
               title={`search ${type}`}
               to={searchTypeLocations[type]}
               activeClassName={styles['is-active']}
+              data-test-search-type-button={type}
             >
               {capitalize(type)}
             </NavLink>

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -23,8 +23,10 @@ export default class SearchPaneset extends React.Component {
     hideFilters: this.props.hideFilters
   };
 
-  componentWillReceiveProps({ hideFilters }) {
-    if (hideFilters !== this.state.hideFilters) {
+  componentWillReceiveProps({ hideFilters, resultsType }) {
+    let isSameSearchType = resultsType === this.props.resultsType;
+
+    if (isSameSearchType && hideFilters !== this.state.hideFilters) {
       this.setState({ hideFilters });
     }
   }

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -50,14 +50,17 @@ class SearchRoute extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const {
+    let {
       location,
       match: { params: { searchType } },
       search: { [searchType]: { content, isPending } }
     } = nextProps;
 
-    // if the search query is empty, reset results
-    if (!isPending && location.search !== this.props.location.search) {
+    let isSameSearchType = searchType === this.props.match.params.searchType;
+    let isDifferentSearch = location.search !== this.props.location.search;
+
+    // searching the same set, if the search query is empty, reset results
+    if (isSameSearchType && !isPending && isDifferentSearch) {
       const pathQuery = queryString.parse(location.search);
 
       if (content.length > 0 && !pathQuery.search) {

--- a/tests/package-search-test.js
+++ b/tests/package-search-test.js
@@ -1,6 +1,6 @@
 /* global describe, beforeEach */
 import { expect } from 'chai';
-import it from './it-will';
+import it, { convergeOn } from './it-will';
 
 import { describeApplication } from './helpers';
 import PackageSearchPage from './pages/package-search';
@@ -36,6 +36,37 @@ describeApplication('PackageSearch', () => {
 
       it('only shows a single result', () => {
         expect(PackageSearchPage.$searchResultsItems).to.have.lengthOf(1);
+      });
+    });
+
+    describe('clicking another search type', () => {
+      beforeEach(() => {
+        return convergeOn(() => {
+          // wait for the previous search to complete
+          expect(PackageSearchPage.$searchResultsItems).to.have.lengthOf(3);
+        }).then(() => PackageSearchPage.changeSearchType('titles'));
+      });
+
+      it('displays an empty search', () => {
+        expect(PackageSearchPage.$searchField).to.have.value('');
+      });
+
+      it('does not display any more results', () => {
+        expect(PackageSearchPage.$searchResultsItems).to.have.lengthOf(0);
+      });
+
+      describe('navigating back to packages search', () => {
+        beforeEach(() => {
+          return PackageSearchPage.changeSearchType('packages');
+        });
+
+        it('displays the original search', () => {
+          expect(PackageSearchPage.$searchField).to.have.value('Package');
+        });
+
+        it('displays the original search results', () => {
+          expect(PackageSearchPage.$searchResultsItems).to.have.lengthOf(3);
+        });
       });
     });
   });

--- a/tests/pages/package-search.js
+++ b/tests/pages/package-search.js
@@ -1,4 +1,6 @@
 import $ from 'jquery';
+import { expect } from 'chai';
+import { convergeOn } from '../it-will';
 import { triggerChange } from '../helpers';
 
 export default {
@@ -30,5 +32,10 @@ export default {
     window.setTimeout(() => {
       $('[data-test-search-submit]').trigger('click');
     }, 1);
+  },
+
+  changeSearchType(searchType) {
+    $(`[data-test-search-type-button="${searchType}"]`).get(0).click();
+    return convergeOn(() => expect($(`[data-test-search-form="${searchType}"]`)).to.exist);
   }
 };

--- a/tests/pages/title-search.js
+++ b/tests/pages/title-search.js
@@ -1,4 +1,6 @@
 import $ from 'jquery';
+import { expect } from 'chai';
+import { convergeOn } from '../it-will';
 import { triggerChange } from '../helpers';
 
 export default {
@@ -30,5 +32,10 @@ export default {
     window.setTimeout(() => {
       $('[data-test-search-submit]').trigger('click');
     }, 1);
+  },
+
+  changeSearchType(searchType) {
+    $(`[data-test-search-type-button="${searchType}"]`).get(0).click();
+    return convergeOn(() => expect($(`[data-test-search-form="${searchType}"]`)).to.exist);
   }
 };

--- a/tests/pages/vendor-search.js
+++ b/tests/pages/vendor-search.js
@@ -1,4 +1,6 @@
 import $ from 'jquery';
+import { expect } from 'chai';
+import { convergeOn } from '../it-will';
 import { triggerChange } from '../helpers';
 
 export default {
@@ -30,5 +32,10 @@ export default {
     window.setTimeout(() => {
       $('[data-test-search-submit]').trigger('click');
     }, 1);
+  },
+
+  changeSearchType(searchType) {
+    $(`[data-test-search-type-button="${searchType}"]`).get(0).click();
+    return convergeOn(() => expect($(`[data-test-search-form="${searchType}"]`)).to.exist);
   }
 };

--- a/tests/title-search-test.js
+++ b/tests/title-search-test.js
@@ -1,6 +1,6 @@
 /* global describe, beforeEach */
 import { expect } from 'chai';
-import it from './it-will';
+import it, { convergeOn } from './it-will';
 
 import { describeApplication } from './helpers';
 import TitleSearchPage from './pages/title-search';
@@ -36,6 +36,37 @@ describeApplication('TitleSearch', () => {
 
       it('only shows a single result', () => {
         expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(1);
+      });
+    });
+
+    describe('clicking another search type', () => {
+      beforeEach(() => {
+        return convergeOn(() => {
+          // wait for the previous search to complete
+          expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3);
+        }).then(() => TitleSearchPage.changeSearchType('vendors'));
+      });
+
+      it('displays an empty search', () => {
+        expect(TitleSearchPage.$searchField).to.have.value('');
+      });
+
+      it('does not display any more results', () => {
+        expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(0);
+      });
+
+      describe('navigating back to titles search', () => {
+        beforeEach(() => {
+          return TitleSearchPage.changeSearchType('titles');
+        });
+
+        it('displays the original search', () => {
+          expect(TitleSearchPage.$searchField).to.have.value('Title');
+        });
+
+        it('displays the original search results', () => {
+          expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3);
+        });
       });
     });
   });

--- a/tests/vendor-search-test.js
+++ b/tests/vendor-search-test.js
@@ -1,6 +1,6 @@
 /* global describe, beforeEach */
 import { expect } from 'chai';
-import it from './it-will';
+import it, { convergeOn } from './it-will';
 
 import { describeApplication } from './helpers';
 import VendorSearchPage from './pages/vendor-search';
@@ -48,6 +48,37 @@ describeApplication('VendorSearch', () => {
 
     describe('sorting by name', () => {
       it('sorts by name');
+    });
+
+    describe('clicking another search type', () => {
+      beforeEach(() => {
+        return convergeOn(() => {
+          // wait for the previous search to complete
+          expect(VendorSearchPage.$searchResultsItems).to.have.lengthOf(3);
+        }).then(() => VendorSearchPage.changeSearchType('packages'));
+      });
+
+      it('displays an empty search', () => {
+        expect(VendorSearchPage.$searchField).to.have.value('');
+      });
+
+      it('does not display any more results', () => {
+        expect(VendorSearchPage.$searchResultsItems).to.have.lengthOf(0);
+      });
+
+      describe('navigating back to vendors search', () => {
+        beforeEach(() => {
+          return VendorSearchPage.changeSearchType('vendors');
+        });
+
+        it('displays the original search', () => {
+          expect(VendorSearchPage.$searchField).to.have.value('Vendor');
+        });
+
+        it('displays the original search results', () => {
+          expect(VendorSearchPage.$searchResultsItems).to.have.lengthOf(3);
+        });
+      });
     });
   });
 


### PR DESCRIPTION
## Purpose
Previously, in a narrow view when switching search types, it would trigger the search pane to close due to the presence of a new `search` query in the URL. Additionally, this trigger caused a new search to be made with the old query but within a different search type.

## Approach
Now in both `componentWillReceiveProps` hooks, we check if we are using the same search type as before, before creating a new search or closing the open search pane.

A few tests were also added to make sure switching between search types keeps the old results when switching back (and doesn't actually cause a new query in a different search type context).

## Screenshots
### Before
![before](https://user-images.githubusercontent.com/5005153/31902896-102e3298-b7ec-11e7-9c17-fcb9207aaf86.gif)

### After
![after](https://user-images.githubusercontent.com/5005153/31902904-1425b470-b7ec-11e7-954b-a8c4abac504f.gif)

