### PR TITLE
Display friendly formatted content type

### DIFF
--- a/mirage/factories/package.js
+++ b/mirage/factories/package.js
@@ -6,11 +6,11 @@ export default Factory.extend({
   isSelected: true,
   selectedCount: 0,
   contentType: () => faker.random.arrayElement([
-    'Online Reference',
-    'Aggregated Full Text',
-    'Abstract and Index',
-    'E-Book',
-    'E-Journal'
+    'OnlineReference',
+    'AggregatedFullText',
+    'AbstractAndIndex',
+    'eBook',
+    'eJournal'
   ]),
 
   withTitles: trait({

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -12,27 +12,27 @@ export default function defaultScenario(server) {
   createVendor('Economist Intelligence Unit', [
     {
       packageName: 'Business Briefings',
-      contentType: 'Aggregated Full Text',
+      contentType: 'AggregatedFullText',
       titleCount: 9
     },
     {
       packageName: 'Country Reports & Profiles (EIU)',
-      contentType: 'Aggregated Full Text',
+      contentType: 'AggregatedFullText',
       titleCount: 3
     },
     {
       packageName: 'EIU CityData',
-      contentType: 'Online Reference',
+      contentType: 'OnlineReference',
       titleCount: 1
     },
     {
       packageName: 'EIU Complete Country Coverage',
-      contentType: 'Online Reference',
+      contentType: 'OnlineReference',
       titleCount: 1
     },
     {
       packageName: 'EIU: Country Reports Archive (DFG Nationallizenz)',
-      contentType: 'Aggregated Full Text',
+      contentType: 'AggregatedFullText',
       titleCount: 2
     }
   ]);
@@ -40,32 +40,32 @@ export default function defaultScenario(server) {
   createVendor('Edinburgh University Press', [
     {
       packageName: 'Digimap Ordnance Survey',
-      contentType: 'Online Reference',
+      contentType: 'OnlineReference',
       titleCount: 1
     },
     {
-      packageName: 'Edinburch University Press',
-      contentType: 'E-Journal',
+      packageName: 'EdinburchUniversityPress',
+      contentType: 'EJournal',
       titleCount: 2
     },
     {
-      packageName: 'Edinburgh University Press (NESLi2)',
-      contentType: 'E-Journal',
+      packageName: 'EdinburghUniversityPress (NESLi2)',
+      contentType: 'EJournal',
       titleCount: 3
     },
     {
       packageName: 'Edinburgh University Press (SHEDL)',
-      contentType: 'E-Journal',
+      contentType: 'EJournal',
       titleCount: 2
     },
     {
       packageName: 'Edinburgh University Press Complete Collection (JISC)',
-      contentType: 'E-Journal',
+      contentType: 'EJournal',
       titleCount: 6
     },
     {
       packageName: 'Edinburgh University Press Complete Collection (SHEDL)',
-      contentType: 'E-Journal',
+      contentType: 'EJournal',
       titleCount: 3
     }
   ]);

--- a/src/redux/customer-resource.js
+++ b/src/redux/customer-resource.js
@@ -7,6 +7,7 @@ import {
   createRequestReducer,
   createRequestEpic
 } from './request';
+import formatContentType from './utilities';
 
 // customer-resource action creators
 export const getCustomerResource = createRequestCreator('customer-resource');
@@ -54,6 +55,7 @@ export const customerResourceEpics = combineEpics(
     deserialize: (payload) => {
       if (payload) {
         let { customerResourcesList, ...title } = payload;
+        customerResourcesList[0].contentType = formatContentType(customerResourcesList[0].contentType);
 
         return {
           ...title,

--- a/src/redux/package.js
+++ b/src/redux/package.js
@@ -5,6 +5,7 @@ import {
   createRequestReducer,
   createRequestEpic
 } from './request';
+import formatContentType from './utilities';
 
 // package action creators
 export const getPackage = createRequestCreator('package');
@@ -28,7 +29,11 @@ export const packageEpics = combineEpics(
     name: 'package',
     endpoint: ({ vendorId, packageId }) => (
       `eholdings/vendors/${vendorId}/packages/${packageId}`
-    )
+    ),
+    deserialize: (payload) => {
+      payload.contentType = formatContentType(payload.contentType);
+      return payload;
+    }
   }),
   createRequestEpic({
     name: 'package-titles',

--- a/src/redux/utilities.js
+++ b/src/redux/utilities.js
@@ -1,0 +1,14 @@
+export default function formatContentType(contentType) {
+  let contentTypes = {
+    all: 'All',
+    aggregatedfulltext: 'Aggregated Full Text',
+    abstractandindex: 'Abstract and Index',
+    ebook: 'E-Book',
+    ejournal: 'E-Journal',
+    print: 'Print',
+    unknown: 'Unknown',
+    onlinereference: 'Online Reference'
+  };
+
+  return contentTypes[contentType.toLowerCase()];
+}

--- a/tests/customer-resource-show-test.js
+++ b/tests/customer-resource-show-test.js
@@ -18,7 +18,7 @@ describeApplication('CustomerResourceShow', () => {
     vendorPackage = this.server.create('package', 'withTitles', {
       vendor,
       packageName: 'Cool Package',
-      contentType: 'e-book',
+      contentType: 'ebook',
       titleCount: 5
     });
 
@@ -61,7 +61,7 @@ describeApplication('CustomerResourceShow', () => {
     });
 
     it('displays the content type', () => {
-      expect(ResourcePage.contentType).to.equal(resource.package.contentType);
+      expect(ResourcePage.contentType).to.equal('E-Book');
     });
 
     it('displays the managed url', () => {

--- a/tests/package-show-custom-coverage-test.js
+++ b/tests/package-show-custom-coverage-test.js
@@ -26,7 +26,7 @@ describeApplication('PackageShowCustomCoverage', () => {
         customCoverage,
         vendor,
         packageName: 'Cool Package',
-        contentType: 'e-book'
+        contentType: 'ebook'
       });
 
       return this.visit(`/eholdings/vendors/${vendor.id}/packages/${pkg.id}`, () => {
@@ -44,7 +44,7 @@ describeApplication('PackageShowCustomCoverage', () => {
       pkg = this.server.create('package', {
         vendor,
         packageName: 'Cool Package',
-        contentType: 'e-book'
+        contentType: 'ebook'
       });
 
       return this.visit(`/eholdings/vendors/${vendor.id}/packages/${pkg.id}`, () => {

--- a/tests/package-show-test.js
+++ b/tests/package-show-test.js
@@ -18,7 +18,7 @@ describeApplication('PackageShow', () => {
     vendorPackage = this.server.create('package', 'withTitles', {
       vendor,
       packageName: 'Cool Package',
-      contentType: 'e-book',
+      contentType: 'ebook',
       titleCount: 5
     });
 
@@ -41,7 +41,7 @@ describeApplication('PackageShow', () => {
     });
 
     it('displays the content type', () => {
-      expect(PackageShowPage.contentType).to.equal('e-book');
+      expect(PackageShowPage.contentType).to.equal('E-Book');
     });
 
     it('displays the total number of titles', () => {

--- a/tests/package-show-visibility-test.js
+++ b/tests/package-show-visibility-test.js
@@ -20,7 +20,7 @@ describeApplication('PackageShowVisibility', () => {
       pkg = this.server.create('package', 'isHidden', {
         vendor,
         packageName: 'Cool Package',
-        contentType: 'e-book'
+        contentType: 'ebook'
       });
 
       return this.visit(`/eholdings/vendors/${vendor.id}/packages/${pkg.id}`, () => {
@@ -38,7 +38,7 @@ describeApplication('PackageShowVisibility', () => {
       pkg = this.server.create('package', {
         vendor,
         packageName: 'Cool Package',
-        contentType: 'e-book'
+        contentType: 'ebook'
       });
 
       return this.visit(`/eholdings/vendors/${vendor.id}/packages/${pkg.id}`, () => {


### PR DESCRIPTION
## Purpose
We want to show prettily-formatted content types instead of exactly what the RM API returned.
https://issues.folio.org/browse/UIEH-86

## Approach
In the `package` and `customer-resource` reducers, transform the `contentType` when deserializing the server response.

## Next Steps
We probably want to do this serialization step in `mod-kb-ebsco` instead of in the front-end, because the mappings will change for every knowledge base. 
