### PR TITLE
Bulletproof against missing contentType

### DIFF
--- a/src/redux/customer-resource.js
+++ b/src/redux/customer-resource.js
@@ -55,7 +55,9 @@ export const customerResourceEpics = combineEpics(
     deserialize: (payload) => {
       if (payload) {
         let { customerResourcesList, ...title } = payload;
-        customerResourcesList[0].contentType = formatContentType(customerResourcesList[0].contentType);
+        if (customerResourcesList[0] && customerResourcesList[0].contentType) {
+          customerResourcesList[0].contentType = formatContentType(customerResourcesList[0].contentType);
+        }
 
         return {
           ...title,

--- a/src/redux/package.js
+++ b/src/redux/package.js
@@ -31,7 +31,9 @@ export const packageEpics = combineEpics(
       `eholdings/vendors/${vendorId}/packages/${packageId}`
     ),
     deserialize: (payload) => {
-      payload.contentType = formatContentType(payload.contentType);
+      if (payload.contentType) {
+        payload.contentType = formatContentType(payload.contentType);
+      }
       return payload;
     }
   }),

--- a/src/redux/utilities.js
+++ b/src/redux/utilities.js
@@ -10,5 +10,9 @@ export default function formatContentType(contentType) {
     onlinereference: 'Online Reference'
   };
 
-  return contentTypes[contentType.toLowerCase()];
+  if (contentType) {
+    return contentTypes[contentType.toLowerCase()];
+  } else {
+    return contentType;
+  }
 }

--- a/src/redux/utilities.js
+++ b/src/redux/utilities.js
@@ -10,8 +10,10 @@ export default function formatContentType(contentType) {
     onlinereference: 'Online Reference'
   };
 
-  if (contentType) {
-    return contentTypes[contentType.toLowerCase()];
+  let contentTypeKey = contentType.toLowerCase();
+
+  if (contentType && Object.prototype.hasOwnProperty.call(contentTypes, contentTypeKey)) {
+    return contentTypes[contentTypeKey];
   } else {
     return contentType;
   }

--- a/tests/customer-resource-show-test.js
+++ b/tests/customer-resource-show-test.js
@@ -162,6 +162,39 @@ describeApplication('CustomerResourceShow', () => {
     });
   });
 
+  describe('visiting the customer resource page with some attributes undefined', () => {
+    beforeEach(function () {
+      vendorPackage = this.server.create('package', 'withTitles', {
+        vendor,
+        packageName: 'Cool Package',
+        contentType: '',
+        titleCount: 5
+      });
+
+      let title = this.server.create('title', {
+        package: vendorPackage
+      });
+
+      resource = this.server.create('customer-resource', {
+        package: vendorPackage,
+        isSelected: false,
+        title
+      });
+
+      return this.visit(`/eholdings/vendors/${vendor.id}/packages/${vendorPackage.id}/titles/${resource.titleId}`, () => {
+        expect(ResourcePage.$root).to.exist;
+      });
+    });
+
+    it('displays the title name', () => {
+      expect(ResourcePage.titleName).to.equal(resource.title.titleName);
+    });
+
+    it('does not display a content type', () => {
+      expect(ResourcePage.contentType).to.equal('');
+    });
+  });
+
   describe('encountering a server error', () => {
     beforeEach(function () {
       this.server.get('/vendors/:vendorId/packages/:packageId/titles/:titleId', [{

--- a/tests/customer-resource-show-test.js
+++ b/tests/customer-resource-show-test.js
@@ -195,6 +195,39 @@ describeApplication('CustomerResourceShow', () => {
     });
   });
 
+  describe('visiting the customer resource page with unknown attribute value', () => {
+    beforeEach(function () {
+      vendorPackage = this.server.create('package', 'withTitles', {
+        vendor,
+        packageName: 'Cool Package',
+        contentType: 'Isolinear Chip',
+        titleCount: 5
+      });
+
+      let title = this.server.create('title', {
+        package: vendorPackage
+      });
+
+      resource = this.server.create('customer-resource', {
+        package: vendorPackage,
+        isSelected: false,
+        title
+      });
+
+      return this.visit(`/eholdings/vendors/${vendor.id}/packages/${vendorPackage.id}/titles/${resource.titleId}`, () => {
+        expect(ResourcePage.$root).to.exist;
+      });
+    });
+
+    it('displays the title name', () => {
+      expect(ResourcePage.titleName).to.equal(resource.title.titleName);
+    });
+
+    it('does not display a content type', () => {
+      expect(ResourcePage.contentType).to.equal('Isolinear Chip');
+    });
+  });
+
   describe('encountering a server error', () => {
     beforeEach(function () {
       this.server.get('/vendors/:vendorId/packages/:packageId/titles/:titleId', [{


### PR DESCRIPTION
## Purpose
Sometimes a customer resource / package-title will come back from the RM API without a `contentType`. The implementation in https://github.com/thefrontside/ui-eholdings/pull/96 ignored that case, and we would get this error:

![folio frontside io-eholdings-vendors-19-packages-2516-titles-480368 iphone 5](https://user-images.githubusercontent.com/230597/32005915-14876ee2-b96b-11e7-8d1c-4ea6ba276622.png)

## Approach
Put in some checks against a blank or missing `contentType` for both packages and customer resources.