### PR TITLE
Add tests for search type removal

### DIFF
--- a/mirage/factories/vendor.js
+++ b/mirage/factories/vendor.js
@@ -11,8 +11,9 @@ export default Factory.extend({
       // for this vendor here.
 
       if (vendor.packagesTotal > 0) {
-        // Decide how many will be selected (0 to packagesTotal)
-        vendor.packagesSelected = faker.random.number({ min: 0, max: vendor.packagesTotal });
+        // Decide how many will be selected if not already (0 to packagesTotal)
+        vendor.packagesSelected = vendor.packagesSelected ||
+          faker.random.number({ min: 0, max: vendor.packagesTotal });
 
         server.createList('package', vendor.packagesSelected, 'withTitles', {
           vendor,

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -43,6 +43,7 @@ export function describeApplication(name, setup, describe = window.describe) {
       this.app = render(<TestHarness />, rootElement);
 
       this.visit = visit.bind(null, this); // eslint-disable-line no-use-before-define
+      this.goBack = goBack.bind(null, this); // eslint-disable-line no-use-before-define
     });
 
     afterEach(function () {
@@ -84,14 +85,31 @@ describeApplication.only = function (name, setup) {
  *   });
  *
  * @param {Object} context - a mocha test context.
- * @param {string|Location} - where to navigate.
- * @param {function} - assertion to run to ensure that the navigation
- * worked.
+ * @param {String|Location} path - where to navigate.
+ * @param {Function} convergenceCheck - assertion to run to ensure
+ * that the navigation worked.
  * @return {Promise} resolved when navigation is complete.
  */
 function visit(context, path, convergenceCheck) {
   if (context.app) {
     context.app.visit(path);
+  }
+
+  return convergeOn.call(context, convergenceCheck);
+}
+
+/**
+ * Triggers navigating back through the history, and ensures thiat it
+ * happens correctly.
+ *
+ * @param {Object} context - a mocha test context.
+ * @param {Function} convergenceCheck - assertion to run to ensure
+ * that the navigation worked.
+ * @returns {Promise} resolved when navigation is complete
+ */
+function goBack(context, convergenceCheck) {
+  if (context.app) {
+    context.app.history.goBack();
   }
 
   return convergeOn.call(context, convergenceCheck);

--- a/tests/package-search-test.js
+++ b/tests/package-search-test.js
@@ -9,7 +9,7 @@ describeApplication('PackageSearch', () => {
   let pkgs;
 
   beforeEach(function () {
-    pkgs = this.server.createList('package', 3, 'withVendor', {
+    pkgs = this.server.createList('package', 3, 'withVendor', 'withTitles', {
       packageName: i => `Package${i + 1}`,
       titleCount: 3,
       selectedCount: 1
@@ -64,6 +64,30 @@ describeApplication('PackageSearch', () => {
 
         it('hides the preview pane', () => {
           expect(PackageSearchPage.previewPaneIsVisible).to.be.false;
+        });
+      });
+
+      describe('clicking an item within the preview pane', () => {
+        beforeEach(() => {
+          return PackageSearchPage.clickTitle(0);
+        });
+
+        it('hides the search ui', () => {
+          expect(PackageSearchPage.$root).to.not.exist;
+        });
+
+        describe('and going back', () => {
+          beforeEach(function () {
+            return this.goBack(() => expect(PackageSearchPage.$root).to.exist);
+          });
+
+          it('displays the original search', () => {
+            expect(PackageSearchPage.$searchField).to.have.value('Package');
+          });
+
+          it('displays the original search results', () => {
+            expect(PackageSearchPage.$searchResultsItems).to.have.lengthOf(3);
+          });
         });
       });
     });

--- a/tests/pages/package-search.js
+++ b/tests/pages/package-search.js
@@ -71,5 +71,15 @@ export default {
   changeSearchType(searchType) {
     $(`[data-test-search-type-button="${searchType}"]`).get(0).click();
     return convergeOn(() => expect($(`[data-test-search-form="${searchType}"]`)).to.exist);
+  },
+
+  clickTitle(index) {
+    let $title = null;
+
+    // wait until the item exists before clicking
+    return convergeOn(() => {
+      $title = $('[data-test-eholdings-title-list-item] a');
+      expect($title.eq(index)).to.exist;
+    }).then(() => $title.get(index).click());
   }
 };

--- a/tests/pages/title-search.js
+++ b/tests/pages/title-search.js
@@ -71,5 +71,15 @@ export default {
   changeSearchType(searchType) {
     $(`[data-test-search-type-button="${searchType}"]`).get(0).click();
     return convergeOn(() => expect($(`[data-test-search-form="${searchType}"]`)).to.exist);
+  },
+
+  clickPackage(index) {
+    let $pkg = null;
+
+    // wait until the item exists before clicking
+    return convergeOn(() => {
+      $pkg = $('[data-test-eholdings-package-list-item] a');
+      expect($pkg.eq(index)).to.exist;
+    }).then(() => $pkg.get(index).click());
   }
 };

--- a/tests/pages/vendor-search.js
+++ b/tests/pages/vendor-search.js
@@ -71,5 +71,15 @@ export default {
   changeSearchType(searchType) {
     $(`[data-test-search-type-button="${searchType}"]`).get(0).click();
     return convergeOn(() => expect($(`[data-test-search-form="${searchType}"]`)).to.exist);
+  },
+
+  clickPackage(index) {
+    let $pkg = null;
+
+    // wait until the item exists before clicking
+    return convergeOn(() => {
+      $pkg = $('[data-test-eholdings-package-list-item] a');
+      expect($pkg.eq(index)).to.exist;
+    }).then(() => $pkg.get(index).click());
   }
 };

--- a/tests/title-search-test.js
+++ b/tests/title-search-test.js
@@ -9,7 +9,7 @@ describeApplication('TitleSearch', () => {
   let titles;
 
   beforeEach(function () {
-    titles = this.server.createList('title', 3, {
+    titles = this.server.createList('title', 3, 'withPackages', {
       titleName: i => `Title${i + 1}`
     });
 
@@ -66,6 +66,30 @@ describeApplication('TitleSearch', () => {
 
         it('hides the preview pane', () => {
           expect(TitleSearchPage.previewPaneIsVisible).to.be.false;
+        });
+      });
+
+      describe('clicking an item within the preview pane', () => {
+        beforeEach(() => {
+          return TitleSearchPage.clickPackage(0);
+        });
+
+        it('hides the search ui', () => {
+          expect(TitleSearchPage.$root).to.not.exist;
+        });
+
+        describe('and going back', () => {
+          beforeEach(function () {
+            return this.goBack(() => expect(TitleSearchPage.$root).to.exist);
+          });
+
+          it('displays the original search', () => {
+            expect(TitleSearchPage.$searchField).to.have.value('Title');
+          });
+
+          it('displays the original search results', () => {
+            expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3);
+          });
         });
       });
     });

--- a/tests/vendor-search-test.js
+++ b/tests/vendor-search-test.js
@@ -7,7 +7,7 @@ import VendorSearchPage from './pages/vendor-search';
 
 describeApplication('VendorSearch', () => {
   beforeEach(function () {
-    this.server.createList('vendor', 3, {
+    this.server.createList('vendor', 3, 'withPackagesAndTitles', {
       name: i => `Vendor${i + 1}`,
       packagesSelected: 1,
       packagesTotal: 3
@@ -66,6 +66,30 @@ describeApplication('VendorSearch', () => {
 
         it('hides the preview pane', () => {
           expect(VendorSearchPage.previewPaneIsVisible).to.be.false;
+        });
+      });
+
+      describe('clicking an item within the preview pane', () => {
+        beforeEach(() => {
+          return VendorSearchPage.clickPackage(0);
+        });
+
+        it('hides the search ui', () => {
+          expect(VendorSearchPage.$root).to.not.exist;
+        });
+
+        describe('and going back', () => {
+          beforeEach(function () {
+            return this.goBack(() => expect(VendorSearchPage.$root).to.exist);
+          });
+
+          it('displays the original search', () => {
+            expect(VendorSearchPage.$searchField).to.have.value('Vendor');
+          });
+
+          it('displays the original search results', () => {
+            expect(VendorSearchPage.$searchResultsItems).to.have.lengthOf(3);
+          });
         });
       });
     });


### PR DESCRIPTION
## Purpose
PR #99 got merged a little quick before @cowboyd got his review in. We need to test the functionality of that PR to ensure no regressions happen in the future.

## Approach
- Adds a `goBack` helper which navigates backwards through our apps router history using the `TestHarness`'s `history` property.
- Creates additional mirage data during tests to click deeply inside of the preview pane on the various search routes.
- Tests that clicking deeply hides the search UI and navigating back shows it again.
