### PR TITLE
Implement toggling a package's selected state

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -106,6 +106,22 @@ export default function configure() {
     });
   });
 
+  this.put('/vendors/:vendorId/packages/:packageId', ({ packages, customerResources }, request) => {
+    let matchingPackage = packages.findBy({
+      vendorId: request.params.vendorId,
+      id: request.params.packageId
+    });
+
+    let matchingCustomerResources = customerResources.where({
+      packageId: request.params.packageId
+    });
+
+    let { isSelected } = JSON.parse(request.requestBody);
+
+    matchingCustomerResources.update('isSelected', isSelected).save();
+    matchingPackage.update('isSelected', isSelected).save();
+  });
+
   this.get('/vendors/:vendorId/packages/:packageId/titles', ({ customerResources }, request) => {
     return customerResources.where({ packageId: request.params.packageId });
   });

--- a/src/components/package-show.js
+++ b/src/components/package-show.js
@@ -6,8 +6,14 @@ import Icon from '@folio/stripes-components/lib/Icon';
 import KeyValueLabel from './key-value-label';
 import List from './list';
 import TitleListItem from './title-list-item';
+import ToggleSwitch from './toggle-switch';
 
-export default function PackageShow({ vendorPackage, packageTitles }, { intl }) {
+export default function PackageShow({
+  vendorPackage,
+  packageTitles,
+  toggleRequest,
+  toggleSelected
+}, { intl }) {
   let packageRecord = vendorPackage.content;
 
   let formatISODateWithoutTime = (dateString) => {
@@ -67,11 +73,19 @@ export default function PackageShow({ vendorPackage, packageTitles }, { intl }) 
 
           <hr />
 
-          <KeyValueLabel label="Selected">
-            <div data-test-eholdings-package-details-selected>
-              {packageRecord.isSelected ? 'Yes' : 'No'}
-            </div>
-          </KeyValueLabel>
+          <label
+            data-test-eholdings-package-details-selected
+            htmlFor="package-details-toggle-switch"
+          >
+            <h4>{packageRecord.isSelected ? 'Selected' : 'Not Selected'}</h4>
+            <ToggleSwitch
+              onChange={toggleSelected}
+              disabled={toggleRequest.isPending}
+              checked={packageRecord.isSelected}
+              isPending={toggleRequest.isPending}
+              id="package-details-toggle-switch"
+            />
+          </label>
 
           <hr />
 
@@ -116,7 +130,9 @@ export default function PackageShow({ vendorPackage, packageTitles }, { intl }) 
 
 PackageShow.propTypes = {
   vendorPackage: PropTypes.object.isRequired,
-  packageTitles: PropTypes.object.isRequired
+  packageTitles: PropTypes.object.isRequired,
+  toggleRequest: PropTypes.object.isRequired,
+  toggleSelected: PropTypes.func.isRequired
 };
 
 PackageShow.contextTypes = {

--- a/src/redux/package.js
+++ b/src/redux/package.js
@@ -1,6 +1,8 @@
 import { combineReducers } from 'redux';
 import { combineEpics } from 'redux-observable';
 import {
+  REQUEST_MAKE,
+  REQUEST_REJECT,
   createRequestCreator,
   createRequestReducer,
   createRequestEpic
@@ -10,26 +12,57 @@ import { formatContentType } from './utilities';
 // package action creators
 export const getPackage = createRequestCreator('package');
 export const getPackageTitles = createRequestCreator('package-titles');
+export const toggleIsSelected = createRequestCreator(
+  'package-toggle-selected',
+  { method: 'PUT' }
+);
 
 // package reducer
 export const packageReducer = combineReducers({
   record: createRequestReducer({
     name: 'package',
-    initialContent: {}
+    initialContent: {},
+    handleRequests: {
+      'package-toggle-selected': (state, action) => {
+        if (action.type === REQUEST_MAKE || action.type === REQUEST_REJECT) {
+          return {
+            ...state,
+            content: {
+              ...state.content,
+              isSelected: !state.content.isSelected
+            }
+          };
+        } else {
+          return {
+            ...state,
+            content: {
+              ...state.content,
+              selectedCount: state.content.isSelected ? state.content.titleCount : 0
+            }
+          };
+        }
+      }
+    }
   }),
   titles: createRequestReducer({
     name: 'package-titles',
     initialContent: []
+  }),
+  toggle: createRequestReducer({
+    name: 'package-toggle-selected'
   })
 });
+
+// package endpoint generator
+const getPackageEndpoint = ({ vendorId, packageId }) => (
+  `eholdings/vendors/${vendorId}/packages/${packageId}`
+);
 
 // package epics
 export const packageEpics = combineEpics(
   createRequestEpic({
     name: 'package',
-    endpoint: ({ vendorId, packageId }) => (
-      `eholdings/vendors/${vendorId}/packages/${packageId}`
-    ),
+    endpoint: getPackageEndpoint,
     deserialize: (payload) => {
       if (payload.contentType) {
         payload.contentType = formatContentType(payload.contentType);
@@ -50,5 +83,10 @@ export const packageEpics = combineEpics(
       offset: 1,
       orderby: 'TitleName'
     }
+  }),
+  createRequestEpic({
+    name: 'package-toggle-selected',
+    endpoint: getPackageEndpoint,
+    serialize: ({ isSelected }) => ({ isSelected })
   })
 );

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -1,4 +1,6 @@
 import $ from 'jquery';
+import { expect } from 'chai';
+import { convergeOn } from '../it-will';
 
 function createTitleObject(element) {
   let $scope = $(element);
@@ -40,7 +42,31 @@ export default {
   },
 
   get isSelected() {
-    return $('[data-test-eholdings-package-details-selected]').text();
+    return $('[data-test-eholdings-package-details-selected]').text() === 'Selected';
+  },
+
+  toggleIsSelected() {
+    /*
+     * We don't want to click the element before it exists.  This should
+     * probably become a generic 'click' helper once we have more usage.
+     */
+    return convergeOn(() => {
+      expect($('[data-test-eholdings-package-details-selected]')).to.exist;
+    }).then(() => (
+      $('[data-test-eholdings-package-details-selected] input').click()
+    ));
+  },
+
+  get isSelecting() {
+    return $('[data-test-eholdings-package-details-selected] [data-test-toggle-switch]').attr('class').indexOf('is-pending--') !== -1;
+  },
+
+  get isSelectedToggleable() {
+    return $('[data-test-eholdings-package-details-selected] input[type=checkbox]').prop('disabled') === false;
+  },
+
+  get allTitlesSelected() {
+    return this.titleList.every(title => title.isSelected);
   },
 
   get hasErrors() {


### PR DESCRIPTION
## Purpose
[UIEH-51](https://issues.folio.org/projects/UIEH/issues/UIEH-51) - Add/Remove package to/from holdings

## Approach
Copied the approach from toggling a customer resource (package-title):
- New request reducer for sending the `PUT` request to the package endpoint
- Existing package reducer now handles the response from the `PUT` request
- The toggle switch component was used in place of the "Yes"/"No" display for packages
- New tests were pretty much copy+pasted and altered from the customer resource tests

To support the titles and selected title count being updated, two additional measures are taken.
- Reload the package titles list once the toggle request has resolved
- Update the selected title count to show all or no titles are selected depending on the package's selected state

### TODO
- [x] ~When a package is selected, it's title's should be reloaded so their display's are updated with whether or not they're selected.~
- [x] ~When a package is selected, it's selected title count display should also be updated with the correct number of selected titles.~

### Open Questions
- Requests are getting hairier when dealing with `PUT`s, so we should look into implementing something to abstract this away (better than what we have in `redux/request.js`). It's possible `stripes-connect` has come further than when we last used it, perhaps it's worth looking back into.

## Screenshots
![image](https://user-images.githubusercontent.com/5005153/32187162-2040ab4e-bd72-11e7-9f00-f12058060c6c.png)

