### PR TITLE
Switch to new JSON API vendor endpoints

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -156,14 +156,14 @@ export default function configure() {
   });
 
   // Vendor resources
-  this.get('/vendors', ({ vendors }, request) => {
+  this.get('/jsonapi/vendors', ({ vendors }, request) => {
     return vendors.all().filter((vendorModel) => {
       let query = request.queryParams.search.toLowerCase();
-      return vendorModel.vendorName.toLowerCase().includes(query);
+      return vendorModel.name.toLowerCase().includes(query);
     });
   });
 
-  this.get('/vendors/:id', ({ vendors }, request) => {
+  this.get('/jsonapi/vendors/:id', ({ vendors }, request) => {
     return vendors.find(request.params.id);
   });
 

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -158,7 +158,7 @@ export default function configure() {
   // Vendor resources
   this.get('/jsonapi/vendors', ({ vendors }, request) => {
     return vendors.all().filter((vendorModel) => {
-      let query = request.queryParams.search.toLowerCase();
+      let query = request.queryParams.q.toLowerCase();
       return vendorModel.name.toLowerCase().includes(query);
     });
   });

--- a/mirage/factories/vendor.js
+++ b/mirage/factories/vendor.js
@@ -1,7 +1,7 @@
 import { Factory, faker, trait } from 'mirage-server';
 
 export default Factory.extend({
-  vendorName: () => faker.company.companyName(),
+  name: () => faker.company.companyName(),
   packagesTotal: 0,
   packagesSelected: 0,
 
@@ -16,14 +16,14 @@ export default Factory.extend({
 
         server.createList('package', vendor.packagesSelected, 'withTitles', {
           vendor,
-          vendorName: vendor.vendorName,
+          vendorName: vendor.name,
           isSelected: true,
           titleCount: faker.random.number({ min: 1, max: 5 })
         });
 
         server.createList('package', (vendor.packagesTotal - vendor.packagesSelected), 'withTitles', {
           vendor,
-          vendorName: vendor.vendorName,
+          vendorName: vendor.name,
           isSelected: false,
           titleCount: faker.random.number({ min: 1, max: 5 })
         });

--- a/mirage/serializers/application.js
+++ b/mirage/serializers/application.js
@@ -61,7 +61,7 @@ export default Serializer.extend({
     return json.customerResourcesList.map((customerResource) => {
       let hash = customerResource;
       hash.vendorId = customerResource.package.vendor.id;
-      hash.vendorName = customerResource.package.vendor.vendorName;
+      hash.vendorName = customerResource.package.vendor.name;
       hash.packageId = customerResource.package.id;
       hash.packageName = customerResource.package.packageName;
       hash.contentType = customerResource.package.contentType;

--- a/mirage/serializers/package.js
+++ b/mirage/serializers/package.js
@@ -7,7 +7,7 @@ export default ApplicationSerializer.extend({
     let newHash = json;
     if (newHash.vendor && !newHash.vendorId) {
       newHash.vendorId = json.vendor.id;
-      newHash.vendorName = json.vendor.vendorName;
+      newHash.vendorName = json.vendor.name;
       delete newHash.vendor;
     }
     return newHash;

--- a/mirage/serializers/vendor.js
+++ b/mirage/serializers/vendor.js
@@ -1,0 +1,19 @@
+import { JSONAPISerializer, camelize } from 'mirage-server';
+
+export default JSONAPISerializer.extend({
+  keyForModel(modelName) {
+    return camelize(modelName);
+  },
+
+  keyForCollection(modelName) {
+    return camelize(modelName);
+  },
+
+  keyForAttribute(attr) {
+    return camelize(attr);
+  },
+
+  keyForRelationship(key) {
+    return camelize(key);
+  }
+});

--- a/src/components/vendor-list-item.js
+++ b/src/components/vendor-list-item.js
@@ -8,7 +8,7 @@ export default function VendorListItem({ item, link }) {
     <li data-test-eholdings-vendor-list-item>
       <Link to={link}>
         <h5 data-test-eholdings-vendor-list-item-name>
-          {item.vendorName}
+          {item.name}
         </h5>
       </Link>
     </li>

--- a/src/components/vendor-search-results.js
+++ b/src/components/vendor-search-results.js
@@ -18,7 +18,7 @@ export default function VendorSearchResults({
     <Icon icon="spinner-ellipsis" />
   ) : isRejected ? (
     <p data-test-vendor-search-error-message>
-      {error.length ? error[0].message : error.message}
+      {error.errors.length ? error.errors[0].title : error.title}
     </p>
   ) : isResolved && !content.length ? (
     <p data-test-vendor-search-no-results>
@@ -28,10 +28,10 @@ export default function VendorSearchResults({
     <List data-test-vendor-search-results-list>
       {content.map(vendor => (
         <VendorListItem
-          key={vendor.vendorId}
+          key={vendor.id}
           item={vendor}
           link={{
-            pathname: `/eholdings/vendors/${vendor.vendorId}`,
+            pathname: `/eholdings/vendors/${vendor.id}`,
             search: location.search
           }}
         />

--- a/src/components/vendor-show.js
+++ b/src/components/vendor-show.js
@@ -16,7 +16,7 @@ export default function VendorShow({ vendor, vendorPackages }) {
           <div style={{ margin: '2rem 0' }}>
             <KeyValueLabel label="Vendor">
               <h1 data-test-eholdings-vendor-details-name>
-                {record.vendorName}
+                {record.name}
               </h1>
             </KeyValueLabel>
           </div>
@@ -56,7 +56,7 @@ export default function VendorShow({ vendor, vendorPackages }) {
         </div>
       ) : vendor.isRejected ? (
         <p data-test-eholdings-vendor-details-error>
-          {vendor.error.length ? vendor.error[0].message : vendor.error.message}
+          {vendor.error.errors.length ? vendor.error.errors[0].title : vendor.error.title}
         </p>
       ) : (
         <Icon icon="spinner-ellipsis" />

--- a/src/redux/request.js
+++ b/src/redux/request.js
@@ -299,21 +299,7 @@ export function createRequestEpic({
               delete query.search;
             }
 
-            // "hack" to prevent query-string from removing/encoding null searches
-            if (query.search === '%00') {
-              let { search, ...queryParams } = query;
-
-              // TODO: make the same for all search types, right now only
-              // vendors has q instead of search
-              if ('q' in query) {
-                searchQuery = `q=${search}&${queryString.stringify(queryParams)}`;
-              } else {
-                searchQuery = `search=${search}&${queryString.stringify(queryParams)}`;
-              }
-            } else {
-              searchQuery = queryString.stringify(query);
-            }
-
+            searchQuery = queryString.stringify(query);
             url = `${url}?${searchQuery}`;
           }
         }

--- a/src/redux/request.js
+++ b/src/redux/request.js
@@ -292,10 +292,24 @@ export function createRequestEpic({
           if (Object.keys(query)) {
             let searchQuery = '';
 
+            // TODO: make the same for all search types, right now only
+            // vendors has q instead of search
+            if ('q' in query) {
+              query.q = query.search;
+              delete query.search;
+            }
+
             // "hack" to prevent query-string from removing/encoding null searches
             if (query.search === '%00') {
-              let { search, ...q } = query;
-              searchQuery = `search=${search}&${queryString.stringify(q)}`;
+              let { search, ...queryParams } = query;
+
+              // TODO: make the same for all search types, right now only
+              // vendors has q instead of search
+              if ('q' in query) {
+                searchQuery = `q=${search}&${queryString.stringify(queryParams)}`;
+              } else {
+                searchQuery = `search=${search}&${queryString.stringify(queryParams)}`;
+              }
             } else {
               searchQuery = queryString.stringify(query);
             }

--- a/src/redux/search.js
+++ b/src/redux/search.js
@@ -7,6 +7,7 @@ import {
   createRequestReducer,
   createRequestEpic
 } from './request';
+import { normalizeJsonApiResource } from './utilities';
 
 // search action creators
 export const searchVendors = createRequestCreator('vendors-search');
@@ -45,18 +46,35 @@ function createSearchEpic(name, {
   recordsKey = name,
   defaultParams = {}
 } = {}) {
-  return createRequestEpic({
-    name: `${name}-search`,
-    endpoint: `eholdings/${name}`,
-    deserialize: payload => (payload ? payload[recordsKey] || [] : []),
-    defaultParams: {
-      search: '',
-      count: 25,
-      offset: 1,
-      orderby: 'relevance',
-      ...defaultParams
-    }
-  });
+  // TODO: when switching package and title search over to JSON API,
+  // only use this version of return createRequestEpic()
+  if (name === 'vendors') {
+    return createRequestEpic({
+      name: `${name}-search`,
+      endpoint: 'eholdings/jsonapi/vendors',
+      deserialize: payload => (payload ? payload.data.map(pkg => normalizeJsonApiResource(pkg)) || [] : []),
+      defaultParams: {
+        search: '',
+        count: 25,
+        offset: 1,
+        orderby: 'relevance',
+        ...defaultParams
+      }
+    });
+  } else {
+    return createRequestEpic({
+      name: `${name}-search`,
+      endpoint: `eholdings/${name}`,
+      deserialize: payload => (payload ? payload[recordsKey] || [] : []),
+      defaultParams: {
+        search: '',
+        count: 25,
+        offset: 1,
+        orderby: 'relevance',
+        ...defaultParams
+      }
+    });
+  }
 }
 
 // search epic

--- a/src/redux/search.js
+++ b/src/redux/search.js
@@ -54,7 +54,7 @@ function createSearchEpic(name, {
       endpoint: 'eholdings/jsonapi/vendors',
       deserialize: payload => (payload ? payload.data.map(pkg => normalizeJsonApiResource(pkg)) || [] : []),
       defaultParams: {
-        search: '',
+        q: '',
         count: 25,
         offset: 1,
         orderby: 'relevance',

--- a/src/redux/utilities.js
+++ b/src/redux/utilities.js
@@ -46,3 +46,10 @@ export function formatPublicationType(publicationType) {
     return publicationType;
   }
 }
+
+export function normalizeJsonApiResource(resource) {
+  return {
+    id: resource.id,
+    ...resource.attributes
+  };
+}

--- a/src/redux/vendor.js
+++ b/src/redux/vendor.js
@@ -5,6 +5,7 @@ import {
   createRequestReducer,
   createRequestEpic
 } from './request';
+import { normalizeJsonApiResource } from './utilities';
 
 // vendor action creators
 export const getVendor = createRequestCreator('vendor');
@@ -26,7 +27,8 @@ export const vendorReducer = combineReducers({
 export const vendorEpics = combineEpics(
   createRequestEpic({
     name: 'vendor',
-    endpoint: ({ vendorId }) => `eholdings/vendors/${vendorId}`
+    endpoint: ({ vendorId }) => `eholdings/jsonapi/vendors/${vendorId}`,
+    deserialize: payload => (payload ? normalizeJsonApiResource(payload.data) : [])
   }),
   createRequestEpic({
     name: 'vendor-packages',

--- a/tests/customer-resource-show-test.js
+++ b/tests/customer-resource-show-test.js
@@ -12,7 +12,7 @@ describeApplication('CustomerResourceShow', () => {
 
   beforeEach(function () {
     vendor = this.server.create('vendor', {
-      vendorName: 'Cool Vendor'
+      name: 'Cool Vendor'
     });
 
     vendorPackage = this.server.create('package', 'withTitles', {
@@ -54,7 +54,7 @@ describeApplication('CustomerResourceShow', () => {
     });
 
     it('displays the vendor name', () => {
-      expect(ResourcePage.vendorName).to.equal(resource.package.vendor.vendorName);
+      expect(ResourcePage.vendorName).to.equal(resource.package.vendor.name);
     });
 
     it('displays the package name', () => {

--- a/tests/package-show-custom-coverage-test.js
+++ b/tests/package-show-custom-coverage-test.js
@@ -11,7 +11,7 @@ describeApplication('PackageShowCustomCoverage', () => {
 
   beforeEach(function () {
     vendor = this.server.create('vendor', {
-      vendorName: 'Cool Vendor'
+      name: 'Cool Vendor'
     });
   });
 

--- a/tests/package-show-test.js
+++ b/tests/package-show-test.js
@@ -12,7 +12,7 @@ describeApplication('PackageShow', () => {
 
   beforeEach(function () {
     vendor = this.server.create('vendor', {
-      vendorName: 'Cool Vendor'
+      name: 'Cool Vendor'
     });
 
     vendorPackage = this.server.create('package', 'withTitles', {

--- a/tests/package-show-visibility-test.js
+++ b/tests/package-show-visibility-test.js
@@ -11,7 +11,7 @@ describeApplication('PackageShowVisibility', () => {
 
   beforeEach(function () {
     vendor = this.server.create('vendor', {
-      vendorName: 'Cool Vendor'
+      name: 'Cool Vendor'
     });
   });
 

--- a/tests/pages/vendor-search.js
+++ b/tests/pages/vendor-search.js
@@ -20,6 +20,10 @@ export default {
     return $('[data-test-vendor-search-error-message]').length > 0;
   },
 
+  get errorMessage() {
+    return $('[data-test-vendor-search-error-message]').text();
+  },
+
   get noResultsMessage() {
     return $('[data-test-vendor-search-no-results]').text();
   },

--- a/tests/pages/vendor-show.js
+++ b/tests/pages/vendor-show.js
@@ -26,12 +26,19 @@ export default {
   get name() {
     return $('[data-test-eholdings-vendor-details-name]').text();
   },
+
   get hasErrors() {
     return $('[data-test-eholdings-vendor-details-error]').length > 0;
   },
+
+  get errorMessage() {
+    return $('[data-test-eholdings-vendor-details-error]').text();
+  },
+
   get numPackages() {
     return $('[data-test-eholdings-vendor-details-packages-total]').text();
   },
+
   get numPackagesSelected() {
     return $('[data-test-eholdings-vendor-details-packages-selected]').text();
   },

--- a/tests/vendor-search-test.js
+++ b/tests/vendor-search-test.js
@@ -8,11 +8,11 @@ import VendorSearchPage from './pages/vendor-search';
 describeApplication('VendorSearch', () => {
   beforeEach(function () {
     this.server.createList('vendor', 3, {
-      vendorName: i => `Vendor${i + 1}`
+      name: i => `Vendor${i + 1}`
     });
 
     this.server.create('vendor', {
-      vendorName: 'Totally Awesome Co'
+      name: 'Totally Awesome Co'
     });
 
     return this.visit('/eholdings/?searchType=vendors', () => {
@@ -121,17 +121,23 @@ describeApplication('VendorSearch', () => {
 
   describe('encountering a server error', () => {
     beforeEach(function () {
-      this.server.get('/vendors', [{
-        message: 'There was an error',
-        code: '1000',
-        subcode: 0
-      }], 500);
+      this.server.get('/jsonapi/vendors', {
+        errors: [
+          {
+            title: 'There was an error'
+          }
+        ]
+      }, 500);
 
       VendorSearchPage.search("this doesn't matter");
     });
 
-    it('dies with dignity', () => {
+    it('shows an error', () => {
       expect(VendorSearchPage.hasErrors).to.be.true;
+    });
+
+    it('displays the error message returned from the server', () => {
+      expect(VendorSearchPage.errorMessage).to.equal('There was an error');
     });
   });
 });

--- a/tests/vendor-show-test.js
+++ b/tests/vendor-show-test.js
@@ -11,7 +11,7 @@ describeApplication('VendorShow', () => {
 
   beforeEach(function () {
     vendor = this.server.create('vendor', 'withPackagesAndTitles', {
-      vendorName: 'League of Ordinary Men',
+      name: 'League of Ordinary Men',
       packagesTotal: 5
     });
 
@@ -56,19 +56,25 @@ describeApplication('VendorShow', () => {
 
   describe('encountering a server error', () => {
     beforeEach(function () {
-      this.server.get('/vendors/:id', [{
-        message: 'There was an error',
-        code: '1000',
-        subcode: 0
-      }], 500);
+      this.server.get('/jsonapi/vendors/:id', {
+        errors: [
+          {
+            title: 'There was an error'
+          }
+        ]
+      }, 500);
 
       return this.visit(`/eholdings/vendors/${vendor.id}`, () => {
         expect(VendorShowPage.$root).to.exist;
       });
     });
 
-    it('dies with dignity', () => {
+    it('has an error', () => {
       expect(VendorShowPage.hasErrors).to.be.true;
+    });
+
+    it('displays the error message returned from the server', () => {
+      expect(VendorShowPage.errorMessage).to.equal('There was an error');
     });
   });
 });


### PR DESCRIPTION
## Purpose
The `/eholdings/vendors` and `/eholdings/vendors/:id` endpoints are now available as JSON API documents at `/eholdings/jsonapi/vendors` and `/eholdings/jsonapi/vendors/:id`.

## Approach
There's a new mirage serializer only for vendors that extends `JSONAPISerializer`, but not the `ApplicationSerializer`.

#### TODOS and Open Questions
- [x] Merge https://github.com/thefrontside/mod-kb-ebsco/pull/17 first.
- [x] Test this implementation against the deployed endpoints.