### PR TITLE
Upgrade stripes-core

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -42,7 +42,7 @@
 
 "@folio/stripes-core@thefrontside/stripes-core#master":
   version "2.7.0"
-  resolved "https://codeload.github.com/thefrontside/stripes-core/tar.gz/f7cebd3126dc3aac04cc163096858634c6c5475b"
+  resolved "https://codeload.github.com/thefrontside/stripes-core/tar.gz/016889a15fad4cd7b264852cb4c055acf44c206d"
   dependencies:
     "@folio/stripes-components" "^1.6.0"
     "@folio/stripes-connect" "^3.0.0-pre.1"


### PR DESCRIPTION
Pulls in newer version of `stripes-core` with a fix for this header css bug:

![32462034-96398682-c2fd-11e7-802e-3575e16bec25](https://user-images.githubusercontent.com/230597/32502631-d912e432-c3a0-11e7-8324-bdee629dba17.gif)

