### PR TITLE
Correct manageCoverageList length check > 0 - avoid incorrect display of 0 length in ui

### DIFF
--- a/src/components/customer-resource-show/customer-resource-show.js
+++ b/src/components/customer-resource-show/customer-resource-show.js
@@ -77,7 +77,7 @@ export default function CustomerResourceShow({ customerResource, toggleRequest, 
             </KeyValueLabel>
           ) }
 
-          {record.managedCoverageList && record.managedCoverageList.length && isValidCoverageList(record.managedCoverageList) && (
+          {record.managedCoverageList && record.managedCoverageList.length > 0 && isValidCoverageList(record.managedCoverageList) && (
             <KeyValueLabel label="Managed Coverage Dates">
               <CoverageDates
                 coverageArray={record.managedCoverageList}

--- a/tests/customer-resource-show-coverage-test.js
+++ b/tests/customer-resource-show-coverage-test.js
@@ -32,7 +32,19 @@ describeApplication('CustomerResourceShowManagedCoverage', () => {
       expect(CustomerResourceShowPage.managedCoverageList).to.equal('');
     });
   });
+  describe('visiting the customer resource page with empty (0 length) managed coverage array', () => {
+    beforeEach(function () {
+      resource.managedCoverageList = this.server.createList('managed-coverage', 0);
+      resource.save();
+      return this.visit(`/eholdings/vendors/${pkg.vendor.id}/packages/${pkg.id}/titles/${resource.id}`, () => {
+        expect(CustomerResourceShowPage.$root).to.exist;
+      });
+    });
 
+    it('does not display the managed coverage section', () => {
+      expect(CustomerResourceShowPage.managedCoverageList).to.equal('');
+    });
+  });
   describe('visiting the customer resource page with single managed coverage', () => {
     beforeEach(function () {
       resource.managedCoverageList = this.server.createList('managed-coverage', 1,


### PR DESCRIPTION
## Purpose
Correct display issue found after release of Managed Coverage Dates on Title Package Display. Specifically a lone 0 appears below manage url in cases where a record has an empty managedCoverageList.

## Approach
Consistent with checks for other lists (such as subject list) 

#### TODOS and Open Questions

## Learning
Even though length of ManagedCoverageList of 0 is falsey - because of the context of where it is used in - the JSX it results in the display of 0 in ui (as in below screenshot)

## Screenshots
![managedcoveragelist-0-length](https://user-images.githubusercontent.com/19415226/32511872-24a6e2be-c3c3-11e7-910a-2b4e788b1c7a.jpg)

and below image shows the offending element in DOM

![image](https://user-images.githubusercontent.com/19415226/32522853-f1fbb780-c3e6-11e7-8252-a88073aff05d.png)