### PR TITLE
Point to sandbox okapi cluster by default

### DIFF
--- a/demo/stripes.config.js
+++ b/demo/stripes.config.js
@@ -1,5 +1,14 @@
+const environment = process.env.NODE_ENV;
+let url;
+
+if (environment === 'production') {
+  url = 'https://okapi.frontside.io';
+} else {
+  url = 'https://okapi-sandbox.frontside.io';
+}
+
 module.exports = {
-  okapi: { url: 'https://okapi.frontside.io', tenant: 'fs' },
+  okapi: { url, tenant: 'fs' },
   config: {
     hasAllPerms: true,
     logCategories: ''


### PR DESCRIPTION
Our sandbox Okapi cluster now points to sandbox RM API.

Our production Okapi cluster now points to production RM API.

With this PR, running `yarn start` or `yarn build` will point to the sandbox cluster, and `environment=production yarn build` (which Travis runs) will point to the production cluster.