### PR TITLE
Don't route Managed URL through React router

### DIFF
--- a/src/components/customer-resource-show/customer-resource-show.js
+++ b/src/components/customer-resource-show/customer-resource-show.js
@@ -72,7 +72,7 @@ export default function CustomerResourceShow({ customerResource, toggleRequest, 
           {record.url && (
             <KeyValueLabel label="Managed URL">
               <div data-test-eholdings-customer-resource-show-managed-url>
-                <Link to={record.url}>{record.url}</Link>
+                <a href={record.url}>{record.url}</a>
               </div>
             </KeyValueLabel>
           ) }


### PR DESCRIPTION
"Managed URL" links are external, but we were treating them as internal and routing them through our application's router.  This changes the "Managed URL" to behave more like a normal link and take us out of the application.
