### PR TITLE
Add other notify endpoint to mirage

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -68,6 +68,11 @@ export default function configure() {
     totalRecords: 0
   });
 
+  this.get('/notify', {
+    notifications: [],
+    totalRecords: 0
+  });
+
   // e-holdings endpoints
   this.namespace = 'eholdings';
 


### PR DESCRIPTION
## Purpose
Mirage spat out a bunch of unhandled route errors when requesting `/notify`. I thought the endpoint might have just changed from `/notify/_self`, but apparently there are two requests for notify that return the same payload at these two endpoints.

## Approach
Adds a second `/notify` endpoint that returns the same payload as `/notify/_self`

#### Open Questions
- _Why?_
