### PR TITLE
Add Back button in eholdings UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist/*
+.vscode

--- a/src/components/customer-resource-show/customer-resource-show.js
+++ b/src/components/customer-resource-show/customer-resource-show.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
 import Icon from '@folio/stripes-components/lib/Icon';
+import PaneHeader from '@folio/stripes-components/lib/PaneHeader';
+import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
+
+import Link from '../link';
 import KeyValueLabel from '../key-value-label';
 import IdentifiersList from '../identifiers-list';
 import ContributorsList from '../contributors-list';
@@ -10,138 +13,164 @@ import CoverageDates from '../coverage-dates';
 import { isBookPublicationType, formatPublicationType, isValidCoverageList, mapMessageReason } from '../utilities';
 import styles from './customer-resource-show.css';
 
-export default function CustomerResourceShow({ customerResource, toggleRequest, toggleSelected }) {
+export default function CustomerResourceShow({
+  customerResource,
+  toggleRequest,
+  toggleSelected,
+  queryString
+}, { router }) {
   const record = customerResource.content;
+  let historyState = router.history.location.state;
 
   return (
-    <div className={styles['detail-container']} data-test-eholdings-customer-resource-show>
-      {customerResource.isResolved ? (
-        <div>
-          <div className={styles['detail-container-header']}>
-            <KeyValueLabel label="Resource">
-              <h1 data-test-eholdings-customer-resource-show-title-name>
-                {record.titleName}
-              </h1>
-            </KeyValueLabel>
-          </div>
-
-          <ContributorsList data={record.contributorsList} />
-
-          <KeyValueLabel label="Publisher">
-            <div data-test-eholdings-customer-resource-show-publisher-name>
-              {record.publisherName}
-            </div>
-          </KeyValueLabel>
-
-          <KeyValueLabel label="Publication Type">
-            <div data-test-eholdings-customer-resource-show-publication-type>
-              {formatPublicationType(record.pubType)}
-            </div>
-          </KeyValueLabel>
-
-          <IdentifiersList data={record.identifiersList} />
-
-          {record.subjectsList && record.subjectsList.length > 0 && (
-            <KeyValueLabel label="Subjects">
-              <div data-test-eholdings-customer-resource-show-subjects-list>
-                {record.subjectsList.map(subjectObj => subjectObj.subject).join('; ')}
-              </div>
-            </KeyValueLabel>
-          ) }
-
-          <KeyValueLabel label="Package">
-            <div data-test-eholdings-customer-resource-show-package-name>
-              <Link to={`/eholdings/vendors/${record.vendorId}/packages/${record.packageId}`}>{record.packageName}</Link>
-            </div>
-          </KeyValueLabel>
-
-          {record.contentType && (
-            <KeyValueLabel label="Content Type">
-              <div data-test-eholdings-customer-resource-show-content-type>
-                {record.contentType}
-              </div>
-            </KeyValueLabel>
-          ) }
-
-          <KeyValueLabel label="Vendor">
-            <div data-test-eholdings-customer-resource-show-vendor-name>
-              <Link to={`/eholdings/vendors/${record.vendorId}`}>{record.vendorName}</Link>
-            </div>
-          </KeyValueLabel>
-
-          {record.url && (
-            <KeyValueLabel label="Managed URL">
-              <div data-test-eholdings-customer-resource-show-managed-url>
-                <a href={record.url}>{record.url}</a>
-              </div>
-            </KeyValueLabel>
-          ) }
-
-          {record.managedCoverageList && record.managedCoverageList.length > 0 && isValidCoverageList(record.managedCoverageList) && (
-            <KeyValueLabel label="Managed Coverage Dates">
-              <CoverageDates
-                coverageArray={record.managedCoverageList}
-                id="customer-resource-show-managed-coverage-list"
-                isYearOnly={isBookPublicationType(record.pubType)}
-              />
-            </KeyValueLabel>
-          ) }
-
-          {record.managedEmbargoPeriod.embargoUnit && record.managedEmbargoPeriod.embargoValue && (
-            <KeyValueLabel label="Managed Embargo Period">
-              <div data-test-eholdings-customer-resource-show-managed-embargo-period>
-                {record.managedEmbargoPeriod.embargoValue} {record.managedEmbargoPeriod.embargoUnit}
-              </div>
-            </KeyValueLabel>
-          ) }
-
-          {record.customEmbargoPeriod.embargoUnit && record.customEmbargoPeriod.embargoValue && (
-            <KeyValueLabel label="Custom Embargo Period">
-              <div data-test-eholdings-customer-resource-show-custom-embargo-period>
-                {record.customEmbargoPeriod.embargoValue} {record.customEmbargoPeriod.embargoUnit}
-              </div>
-            </KeyValueLabel>
-          ) }
-
-          <hr />
-
-          <label
-            data-test-eholdings-customer-resource-show-selected
-            htmlFor="customer-resource-show-toggle-switch"
-          >
-            <h4>{record.isSelected ? 'Selected' : 'Not Selected'}</h4>
-            <ToggleSwitch
-              onChange={toggleSelected}
-              disabled={toggleRequest.isPending}
-              checked={record.isSelected}
-              isPending={toggleRequest.isPending}
-              id="customer-resource-show-toggle-switch"
-            />
-          </label>
-
-          <hr />
-
-          {record.visibilityData.isHidden && (
-            <div data-test-eholdings-customer-resource-show-is-hidden>
-              <p><strong>This resource is hidden.</strong></p>
-              <p data-test-eholdings-customer-resource-show-hidden-reason><em>{mapMessageReason(record.visibilityData.reason)}</em></p>
-              <hr />
-            </div>
+    <div>
+      { !queryString && (
+        <PaneHeader
+          firstMenu={historyState && historyState.eholdings && (
+            <PaneMenu>
+              <button data-test-eholdings-customer-resource-show-back-button onClick={() => router.history.goBack()}><Icon icon="left-arrow" /></button>
+            </PaneMenu>
           )}
-
-          <div>
-            <Link to={`/eholdings/titles/${record.titleId}`}>
-              View all packages that include this title
-            </Link>
-          </div>
-        </div>
-      ) : customerResource.isRejected ? (
-        <p data-test-eholdings-customer-resource-show-error>
-          {customerResource.error.length ? customerResource.error[0].message : customerResource.error.message}
-        </p>
-      ) : (
-        <Icon icon="spinner-ellipsis" />
+        />
       )}
+      <div className={styles['detail-container']} data-test-eholdings-customer-resource-show>
+        {customerResource.isResolved ? (
+          <div>
+            <div className={styles['detail-container-header']}>
+              <KeyValueLabel label="Resource">
+                <h1 data-test-eholdings-customer-resource-show-title-name>
+                  {record.titleName}
+                </h1>
+              </KeyValueLabel>
+            </div>
+
+            <ContributorsList data={record.contributorsList} />
+
+            <KeyValueLabel label="Publisher">
+              <div data-test-eholdings-customer-resource-show-publisher-name>
+                {record.publisherName}
+              </div>
+            </KeyValueLabel>
+
+            <KeyValueLabel label="Publication Type">
+              <div data-test-eholdings-customer-resource-show-publication-type>
+                {formatPublicationType(record.pubType)}
+              </div>
+            </KeyValueLabel>
+
+            <IdentifiersList data={record.identifiersList} /> {record.subjectsList && record.subjectsList.length > 0 && (
+              <KeyValueLabel label="Subjects">
+                <div data-test-eholdings-customer-resource-show-subjects-list>
+                  {record
+                    .subjectsList
+                    .map(subjectObj => subjectObj.subject)
+                    .join('; ')}
+                </div>
+              </KeyValueLabel>
+            )}
+
+            <KeyValueLabel label="Package">
+              <div data-test-eholdings-customer-resource-show-package-name>
+                <Link to={`/eholdings/vendors/${record.vendorId}/packages/${record.packageId}`}>{record.packageName}</Link>
+              </div>
+            </KeyValueLabel>
+
+            {record.contentType && (
+              <KeyValueLabel label="Content Type">
+                <div data-test-eholdings-customer-resource-show-content-type>
+                  {record.contentType}
+                </div>
+              </KeyValueLabel>
+            )}
+
+            <KeyValueLabel label="Vendor">
+              <div data-test-eholdings-customer-resource-show-vendor-name>
+                <Link to={`/eholdings/vendors/${record.vendorId}`}>{record.vendorName}</Link>
+              </div>
+            </KeyValueLabel>
+
+            {record.url && (
+              <KeyValueLabel label="Managed URL">
+                <div data-test-eholdings-customer-resource-show-managed-url>
+                  <a href={record.url}>{record.url}</a>
+                </div>
+              </KeyValueLabel>
+            )}
+
+            {record.managedCoverageList && record.managedCoverageList.length > 0 && isValidCoverageList(record.managedCoverageList) && (
+              <KeyValueLabel label="Managed Coverage Dates">
+                <CoverageDates
+                  coverageArray={record.managedCoverageList}
+                  id="customer-resource-show-managed-coverage-list"
+                  isYearOnly={isBookPublicationType(record.pubType)}
+                />
+              </KeyValueLabel>
+            )}
+
+            {record.managedEmbargoPeriod.embargoUnit && record.managedEmbargoPeriod.embargoValue && (
+              <KeyValueLabel label="Managed Embargo Period">
+                <div data-test-eholdings-customer-resource-show-managed-embargo-period>
+                  {record.managedEmbargoPeriod.embargoValue} {record.managedEmbargoPeriod.embargoUnit}
+                </div>
+              </KeyValueLabel>
+            )}
+
+            {record.customEmbargoPeriod.embargoUnit && record.customEmbargoPeriod.embargoValue && (
+              <KeyValueLabel label="Custom Embargo Period">
+                <div data-test-eholdings-customer-resource-show-custom-embargo-period>
+                  {record.customEmbargoPeriod.embargoValue} {record.customEmbargoPeriod.embargoUnit}
+                </div>
+              </KeyValueLabel>
+            )}
+
+            <hr />
+
+            <label
+              data-test-eholdings-customer-resource-show-selected
+              htmlFor="customer-resource-show-toggle-switch"
+            >
+              <h4>{record.isSelected
+                ? 'Selected'
+                : 'Not Selected'}
+              </h4>
+              <ToggleSwitch
+                onChange={toggleSelected}
+                disabled={toggleRequest.isPending}
+                checked={record.isSelected}
+                isPending={toggleRequest.isPending}
+                id="customer-resource-show-toggle-switch"
+              />
+            </label>
+
+            <hr /> {record.visibilityData.isHidden && (
+              <div data-test-eholdings-customer-resource-show-is-hidden>
+                <p>
+                  <strong>This resource is hidden.</strong>
+                </p>
+                <p data-test-eholdings-customer-resource-show-hidden-reason>
+                  <em>{mapMessageReason(record.visibilityData.reason)}</em>
+                </p>
+                <hr />
+              </div>
+            )}
+
+            <div>
+              <Link to={`/eholdings/titles/${record.titleId}`}>
+                View all packages that include this title
+              </Link>
+            </div>
+          </div>
+        )
+          : customerResource.isRejected
+            ? (
+              <p data-test-eholdings-customer-resource-show-error>
+                {customerResource.error.length
+                  ? customerResource.error[0].message
+                  : customerResource.error.message}
+              </p>
+            )
+            : (<Icon icon="spinner-ellipsis" />)}
+      </div>
     </div>
   );
 }
@@ -149,5 +178,10 @@ export default function CustomerResourceShow({ customerResource, toggleRequest, 
 CustomerResourceShow.propTypes = {
   customerResource: PropTypes.object.isRequired,
   toggleRequest: PropTypes.object.isRequired,
-  toggleSelected: PropTypes.func.isRequired
+  toggleSelected: PropTypes.func.isRequired,
+  queryString: PropTypes.string
+};
+
+CustomerResourceShow.contextTypes = {
+  router: PropTypes.object
 };

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Link } from 'react-router-dom';
+
+export default function InternalLink({
+  to,
+  ...props
+}) {
+  let location = { state: { eholdings: true } };
+
+  if (typeof to === 'string') {
+    location.pathname = to;
+  } else {
+    location = { ...to, ...location };
+  }
+
+  return (
+    <Link to={location} {...props} />
+  );
+}
+
+InternalLink.propTypes = {
+  to: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
+};

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -3,6 +3,38 @@ import PropTypes from 'prop-types';
 
 import { Link } from 'react-router-dom';
 
+/**
+ *
+ * This Link component is used to track the origination
+ * of a link wether its from within the application or not.
+ * Here the Link Component sets the state of eholdings to true. Checks
+ * that 'to' is typeof string. Adds a property 'pathname' to location has
+ * containing the 'pathname' that was passed in. Then is returns a new
+ * <Link to={ location } {...props } /> component
+ * with a location hash containing keys of pathname and state.
+ *
+ * ---  Usage   ---
+ * import Link from 'link';
+ *
+ * <Link to={`/eholdings/vendors/${record.vendorId}/packages/${record.packageId}`}>{record.packageName}</Link>
+ *
+ * --- end Usage ---
+ *
+ * With this added data you can test wether a user
+ * navigated to a section of the app via the use of links vs
+ * pasting in URL to browser using the router history.
+ *
+ * ie. In comsuming component you can check router history.
+ * let historyState = router.history.location.state;
+ *
+ * If you look at historyState it would be
+ * -> Object { eholdings: true }
+ *
+ * However, if a user was to paste in the url
+ * historyState will be undefined which is what we want.
+ *
+ */
+
 export default function InternalLink({
   to,
   ...props

--- a/src/components/package-list-item.js
+++ b/src/components/package-list-item.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Link } from 'react-router-dom';
+import Link from './link';
 
 export default function PackageListItem({ item, link, showTitleCount, showVendorName }) {
   return (

--- a/src/components/package-show/package-show.js
+++ b/src/components/package-show/package-show.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Link } from 'react-router-dom';
 import Icon from '@folio/stripes-components/lib/Icon';
+import PaneHeader from '@folio/stripes-components/lib/PaneHeader';
+import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
+
+import Link from '../link';
 import KeyValueLabel from '../key-value-label';
 import List from '../list';
 import TitleListItem from '../title-list-item';
@@ -14,109 +17,122 @@ export default function PackageShow({
   vendorPackage,
   packageTitles,
   toggleRequest,
-  toggleSelected
-}, { intl }) {
+  toggleSelected,
+  queryString
+}, { intl, router }) {
   let packageRecord = vendorPackage.content;
+  let historyState = router.history.location.state;
 
   return (
-    <div className={styles['detail-container']} data-test-eholdings-package-details>
-      {vendorPackage.isResolved ? (
-        <div>
-          <div className={styles['detail-container-header']}>
-            <KeyValueLabel label="Package">
-              <h1 data-test-eholdings-package-details-name>
-                {packageRecord.packageName}
-              </h1>
-            </KeyValueLabel>
-          </div>
-
-          <KeyValueLabel label="Vendor">
-            <div data-test-eholdings-package-details-vendor>
-              <Link to={`/eholdings/vendors/${packageRecord.vendorId}`}>{packageRecord.vendorName}</Link>
-            </div>
-          </KeyValueLabel>
-
-          {packageRecord.contentType && (
-            <KeyValueLabel label="Content Type">
-              <div data-test-eholdings-package-details-content-type>
-                {packageRecord.contentType}
-              </div>
-            </KeyValueLabel>
-          ) }
-
-          <KeyValueLabel label="Titles Selected">
-            <div data-test-eholdings-package-details-titles-selected>
-              {packageRecord.selectedCount}
-            </div>
-          </KeyValueLabel>
-
-          <KeyValueLabel label="Total Titles">
-            <div data-test-eholdings-package-details-titles-total>
-              {packageRecord.titleCount}
-            </div>
-          </KeyValueLabel>
-
-          {(packageRecord.customCoverage.beginCoverage || packageRecord.customCoverage.endCoverage) && (
-            <KeyValueLabel label="Custom Coverage">
-              <div data-test-eholdings-package-details-custom-coverage>
-                {formatISODateWithoutTime(packageRecord.customCoverage.beginCoverage, intl)} - {formatISODateWithoutTime(packageRecord.customCoverage.endCoverage, intl)}
-              </div>
-            </KeyValueLabel>
+    <div>
+      { !queryString && (
+        <PaneHeader
+          firstMenu={historyState && historyState.eholdings && (
+            <PaneMenu>
+              <button data-test-eholdings-package-details-back-button onClick={() => router.history.goBack()}><Icon icon="left-arrow" /></button>
+            </PaneMenu>
           )}
-
-          <hr />
-
-          <label
-            data-test-eholdings-package-details-selected
-            htmlFor="package-details-toggle-switch"
-          >
-            <h4>{packageRecord.isSelected ? 'Selected' : 'Not Selected'}</h4>
-            <ToggleSwitch
-              onChange={toggleSelected}
-              disabled={toggleRequest.isPending}
-              checked={packageRecord.isSelected}
-              isPending={toggleRequest.isPending}
-              id="package-details-toggle-switch"
-            />
-          </label>
-
-          <hr />
-
-          {packageRecord.visibilityData.isHidden && (
-            <div data-test-eholdings-package-details-is-hidden>
-              <p><strong>This package is hidden.</strong></p>
-              <p><em>{packageRecord.visibilityData.reason}</em></p>
-              <hr />
-            </div>
-          )}
-
-          {packageTitles.isResolved && packageTitles.content.length ? (
-            <div>
-              <h3>Titles</h3>
-              <List data-test-eholdings-package-details-title-list>
-                {packageTitles.content.map(item => (
-                  <TitleListItem
-                    key={item.titleId}
-                    item={item}
-                    link={`/eholdings/vendors/${packageRecord.vendorId}/packages/${packageRecord.packageId}/titles/${item.titleId}`}
-                    showSelected
-                  />
-                ))}
-              </List>
-            </div>
-          ) : packageTitles.isResolved ? (
-            <p>No Titles Found</p>
-          ) : (
-            <Icon icon="spinner-ellipsis" />
-          )}
-        </div>
-      ) : vendorPackage.isRejected ? (
-        <p data-test-eholdings-package-details-error>
-          {vendorPackage.error.length ? vendorPackage.error[0].message : vendorPackage.error.message}
-        </p>
-      ) : (
-        <Icon icon="spinner-ellipsis" />
+        />
       )}
+      <div className={styles['detail-container']} data-test-eholdings-package-details>
+        {vendorPackage.isResolved ? (
+          <div>
+            <div className={styles['detail-container-header']}>
+              <KeyValueLabel label="Package">
+                <h1 data-test-eholdings-package-details-name>
+                  {packageRecord.packageName}
+                </h1>
+              </KeyValueLabel>
+            </div>
+
+            <KeyValueLabel label="Vendor">
+              <div data-test-eholdings-package-details-vendor>
+                <Link to={`/eholdings/vendors/${packageRecord.vendorId}`}>{packageRecord.vendorName}</Link>
+              </div>
+            </KeyValueLabel>
+
+            {packageRecord.contentType && (
+              <KeyValueLabel label="Content Type">
+                <div data-test-eholdings-package-details-content-type>
+                  {packageRecord.contentType}
+                </div>
+              </KeyValueLabel>
+            ) }
+
+            <KeyValueLabel label="Titles Selected">
+              <div data-test-eholdings-package-details-titles-selected>
+                {packageRecord.selectedCount}
+              </div>
+            </KeyValueLabel>
+
+            <KeyValueLabel label="Total Titles">
+              <div data-test-eholdings-package-details-titles-total>
+                {packageRecord.titleCount}
+              </div>
+            </KeyValueLabel>
+
+            {(packageRecord.customCoverage.beginCoverage || packageRecord.customCoverage.endCoverage) && (
+              <KeyValueLabel label="Custom Coverage">
+                <div data-test-eholdings-package-details-custom-coverage>
+                  {formatISODateWithoutTime(packageRecord.customCoverage.beginCoverage, intl)} - {formatISODateWithoutTime(packageRecord.customCoverage.endCoverage, intl)}
+                </div>
+              </KeyValueLabel>
+            )}
+
+            <hr />
+
+            <label
+              data-test-eholdings-package-details-selected
+              htmlFor="package-details-toggle-switch"
+            >
+              <h4>{packageRecord.isSelected ? 'Selected' : 'Not Selected'}</h4>
+              <ToggleSwitch
+                onChange={toggleSelected}
+                disabled={toggleRequest.isPending}
+                checked={packageRecord.isSelected}
+                isPending={toggleRequest.isPending}
+                id="package-details-toggle-switch"
+              />
+            </label>
+
+            <hr />
+
+            {packageRecord.visibilityData.isHidden && (
+              <div data-test-eholdings-package-details-is-hidden>
+                <p><strong>This package is hidden.</strong></p>
+                <p><em>{packageRecord.visibilityData.reason}</em></p>
+                <hr />
+              </div>
+            )}
+
+            {packageTitles.isResolved && packageTitles.content.length ? (
+              <div>
+                <h3>Titles</h3>
+                <List data-test-eholdings-package-details-title-list>
+                  {packageTitles.content.map(item => (
+                    <TitleListItem
+                      key={item.titleId}
+                      item={item}
+                      link={`/eholdings/vendors/${packageRecord.vendorId}/packages/${packageRecord.packageId}/titles/${item.titleId}`}
+                      showSelected
+                    />
+                  ))}
+                </List>
+              </div>
+            ) : packageTitles.isResolved ? (
+              <p>No Titles Found</p>
+            ) : (
+              <Icon icon="spinner-ellipsis" />
+            )}
+          </div>
+        ) : vendorPackage.isRejected ? (
+          <p data-test-eholdings-package-details-error>
+            {vendorPackage.error.length ? vendorPackage.error[0].message : vendorPackage.error.message}
+          </p>
+        ) : (
+          <Icon icon="spinner-ellipsis" />
+        )}
+      </div>
     </div>
   );
 }
@@ -125,9 +141,11 @@ PackageShow.propTypes = {
   vendorPackage: PropTypes.object.isRequired,
   packageTitles: PropTypes.object.isRequired,
   toggleRequest: PropTypes.object.isRequired,
-  toggleSelected: PropTypes.func.isRequired
+  toggleSelected: PropTypes.func.isRequired,
+  queryString: PropTypes.string
 };
 
 PackageShow.contextTypes = {
-  intl: PropTypes.object
+  intl: PropTypes.object,
+  router: PropTypes.object
 };

--- a/src/components/title-list-item.js
+++ b/src/components/title-list-item.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Link } from 'react-router-dom';
+import Link from './link';
 
 export default function TitleListItem({ item, link, showSelected, showPublisherAndType }) {
   return (

--- a/src/components/title-show/title-show.js
+++ b/src/components/title-show/title-show.js
@@ -2,6 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Icon from '@folio/stripes-components/lib/Icon';
+import PaneHeader from '@folio/stripes-components/lib/PaneHeader';
+import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
+
 import KeyValueLabel from '../key-value-label';
 import List from '../list';
 import PackageListItem from '../package-list-item';
@@ -10,68 +13,88 @@ import ContributorsList from '../contributors-list';
 import { formatPublicationType } from '../utilities';
 import styles from './title-show.css';
 
-export default function TitleShow({ title }) {
+export default function TitleShow({
+  title,
+  queryString
+}, { router }) {
   let record = title.content;
+  let historyState = router.history.location.state;
 
   return (
-    <div className={styles['detail-container']} data-test-eholdings-title-show>
-      {title.isResolved ? (
-        <div>
-          <div className={styles['detail-container-header']}>
-            <KeyValueLabel label="Title">
-              <h1 data-test-eholdings-title-show-title-name>
-                {record.titleName}
-              </h1>
-            </KeyValueLabel>
-          </div>
-
-          <ContributorsList data={record.contributorsList} />
-
-          <KeyValueLabel label="Publisher">
-            <div data-test-eholdings-title-show-publisher-name>
-              {record.publisherName}
+    <div>
+      { !queryString && (
+        <PaneHeader
+          firstMenu={historyState && historyState.eholdings && (
+            <PaneMenu>
+              <button data-test-eholdings-title-show-back-button onClick={() => router.history.goBack()}><Icon icon="left-arrow" /></button>
+            </PaneMenu>
+          )}
+        />
+      )}
+      <div className={styles['detail-container']} data-test-eholdings-title-show>
+        {title.isResolved ? (
+          <div>
+            <div className={styles['detail-container-header']}>
+              <KeyValueLabel label="Title">
+                <h1 data-test-eholdings-title-show-title-name>
+                  {record.titleName}
+                </h1>
+              </KeyValueLabel>
             </div>
-          </KeyValueLabel>
 
-          <KeyValueLabel label="Publication Type">
-            <div data-test-eholdings-title-show-publication-type>
-              {formatPublicationType(record.pubType)}
-            </div>
-          </KeyValueLabel>
+            <ContributorsList data={record.contributorsList} />
 
-          <IdentifiersList data={record.identifiersList} />
-
-          {record.subjectsList.length > 0 && (
-            <KeyValueLabel label="Subjects">
-              <div data-test-eholdings-title-show-subjects-list>
-                {record.subjectsList.map(subjectObj => subjectObj.subject).join('; ')}
+            <KeyValueLabel label="Publisher">
+              <div data-test-eholdings-title-show-publisher-name>
+                {record.publisherName}
               </div>
             </KeyValueLabel>
-          ) }
 
-          <hr />
-          <h3>Packages</h3>
-          <List data-test-eholdings-title-show-package-list>
-            {record.customerResourcesList.map(item => (
-              <PackageListItem
-                key={item.packageId}
-                item={item}
-                link={`/eholdings/vendors/${item.vendorId}/packages/${item.packageId}/titles/${record.titleId}`}
-              />
-            ))}
-          </List>
-        </div>
-      ) : title.isRejected ? (
-        <p data-test-eholdings-title-show-error>
-          {title.error.length ? title.error[0].message : title.error.message}
-        </p>
-      ) : (
-        <Icon icon="spinner-ellipsis" />
-      )}
+            <KeyValueLabel label="Publication Type">
+              <div data-test-eholdings-title-show-publication-type>
+                {formatPublicationType(record.pubType)}
+              </div>
+            </KeyValueLabel>
+
+            <IdentifiersList data={record.identifiersList} />
+
+            {record.subjectsList.length > 0 && (
+              <KeyValueLabel label="Subjects">
+                <div data-test-eholdings-title-show-subjects-list>
+                  {record.subjectsList.map(subjectObj => subjectObj.subject).join('; ')}
+                </div>
+              </KeyValueLabel>
+            ) }
+
+            <hr />
+            <h3>Packages</h3>
+            <List data-test-eholdings-title-show-package-list>
+              {record.customerResourcesList.map(item => (
+                <PackageListItem
+                  key={item.packageId}
+                  item={item}
+                  link={`/eholdings/vendors/${item.vendorId}/packages/${item.packageId}/titles/${record.titleId}`}
+                />
+              ))}
+            </List>
+          </div>
+        ) : title.isRejected ? (
+          <p data-test-eholdings-title-show-error>
+            {title.error.length ? title.error[0].message : title.error.message}
+          </p>
+        ) : (
+          <Icon icon="spinner-ellipsis" />
+        )}
+      </div>
     </div>
   );
 }
 
 TitleShow.propTypes = {
-  title: PropTypes.object.isRequired
+  title: PropTypes.object.isRequired,
+  queryString: PropTypes.string
+};
+
+TitleShow.contextTypes = {
+  router: PropTypes.object
 };

--- a/src/components/vendor-list-item.js
+++ b/src/components/vendor-list-item.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Link } from 'react-router-dom';
+import Link from './link';
 
 export default function VendorListItem({ item, link }) {
   return (

--- a/src/components/vendor-show/vendor-show.js
+++ b/src/components/vendor-show/vendor-show.js
@@ -2,71 +2,95 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Icon from '@folio/stripes-components/lib/Icon';
+import PaneHeader from '@folio/stripes-components/lib/PaneHeader';
+import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
+
 import KeyValueLabel from '../key-value-label';
 import List from '../list';
 import PackageListItem from '../package-list-item';
 import styles from './vendor-show.css';
 
-export default function VendorShow({ vendor, vendorPackages }) {
+export default function VendorShow({
+  vendor,
+  vendorPackages,
+  queryString
+}, { router }) {
   const record = vendor.content;
+  let historyState = router.history.location.state;
 
   return (
-    <div className={styles['detail-container']} data-test-eholdings-vendor-details>
-      {vendor.isResolved ? (
-        <div>
-          <div className={styles['detail-container-header']}>
-            <KeyValueLabel label="Vendor">
-              <h1 data-test-eholdings-vendor-details-name>
-                {record.name}
-              </h1>
-            </KeyValueLabel>
-          </div>
-
-          <KeyValueLabel label="Packages Selected">
-            <div data-test-eholdings-vendor-details-packages-selected>
-              {record.packagesSelected}
-            </div>
-          </KeyValueLabel>
-
-          <KeyValueLabel label="Total Packages">
-            <div data-test-eholdings-vendor-details-packages-total>
-              {record.packagesTotal}
-            </div>
-          </KeyValueLabel>
-
-          <hr />
-          {vendorPackages.isResolved && vendorPackages.content.length ? (
-            <div>
-              <h3>Packages</h3>
-              <List>
-                {vendorPackages.content.map(pkg => (
-                  <PackageListItem
-                    key={pkg.packageId}
-                    link={`/eholdings/vendors/${pkg.vendorId}/packages/${pkg.packageId}`}
-                    showTitleCount
-                    item={pkg}
-                  />
-                ))}
-              </List>
-            </div>
-          ) : vendorPackages.isResolved ? (
-            <p>No Packages Found</p>
-          ) : (
-            <Icon icon="spinner-ellipsis" />
+    <div>
+      { !queryString && (
+        <PaneHeader
+          firstMenu={historyState && historyState.eholdings && (
+            <PaneMenu>
+              <button data-test-eholdings-vendor-details-back-button onClick={() => router.history.goBack()}><Icon icon="left-arrow" /></button>
+            </PaneMenu>
           )}
-        </div>
-      ) : vendor.isRejected ? (
-        <p data-test-eholdings-vendor-details-error>
-          {vendor.error.errors.length ? vendor.error.errors[0].title : vendor.error.title}
-        </p>
-      ) : (
-        <Icon icon="spinner-ellipsis" />
+        />
       )}
+      <div className={styles['detail-container']} data-test-eholdings-vendor-details>
+        {vendor.isResolved ? (
+          <div>
+            <div className={styles['detail-container-header']}>
+              <KeyValueLabel label="Vendor">
+                <h1 data-test-eholdings-vendor-details-name>
+                  {record.name}
+                </h1>
+              </KeyValueLabel>
+            </div>
+
+            <KeyValueLabel label="Packages Selected">
+              <div data-test-eholdings-vendor-details-packages-selected>
+                {record.packagesSelected}
+              </div>
+            </KeyValueLabel>
+
+            <KeyValueLabel label="Total Packages">
+              <div data-test-eholdings-vendor-details-packages-total>
+                {record.packagesTotal}
+              </div>
+            </KeyValueLabel>
+
+            <hr />
+            {vendorPackages.isResolved && vendorPackages.content.length ? (
+              <div>
+                <h3>Packages</h3>
+                <List>
+                  {vendorPackages.content.map(pkg => (
+                    <PackageListItem
+                      key={pkg.packageId}
+                      link={`/eholdings/vendors/${pkg.vendorId}/packages/${pkg.packageId}`}
+                      showTitleCount
+                      item={pkg}
+                    />
+                  ))}
+                </List>
+              </div>
+            ) : vendorPackages.isResolved ? (
+              <p>No Packages Found</p>
+            ) : (
+              <Icon icon="spinner-ellipsis" />
+            )}
+          </div>
+        ) : vendor.isRejected ? (
+          <p data-test-eholdings-vendor-details-error>
+            {vendor.error.errors.length ? vendor.error.errors[0].title : vendor.error.title}
+          </p>
+        ) : (
+          <Icon icon="spinner-ellipsis" />
+        )}
+      </div>
     </div>
   );
 }
 
 VendorShow.propTypes = {
   vendor: PropTypes.object.isRequired,
-  vendorPackages: PropTypes.object.isRequired
+  vendorPackages: PropTypes.object.isRequired,
+  queryString: PropTypes.string
+};
+
+VendorShow.contextTypes = {
+  router: PropTypes.object
 };

--- a/tests/customer-resource-show-test.js
+++ b/tests/customer-resource-show-test.js
@@ -111,6 +111,10 @@ describeApplication('CustomerResourceShow', () => {
       expect(ResourcePage.isSelected).to.equal(false);
     });
 
+    it.still('should not display the back button', () => {
+      expect(ResourcePage.$backButton).to.not.exist;
+    });
+
     describe('successfully selecting a package title to add to my holdings', () => {
       beforeEach(function () {
         /*
@@ -121,7 +125,7 @@ describeApplication('CustomerResourceShow', () => {
          * temporarily increasing the mirage server's response time
          * to 50ms.
          * TODO: control timing directly with Mirage
-         */
+        */
         this.server.timing = 50;
         return ResourcePage.toggleIsSelected();
       });
@@ -152,6 +156,7 @@ describeApplication('CustomerResourceShow', () => {
         });
       });
     });
+
 
     describe('unsuccessfully selecting a package title to add to my holdings', () => {
       beforeEach(function () {
@@ -194,6 +199,22 @@ describeApplication('CustomerResourceShow', () => {
           expect(ResourcePage.flashError).to.match(/unable to select/i);
         });
       });
+    });
+  });
+
+  describe('navigating to customer resource page', () => {
+    beforeEach(function () {
+      return this.visit({
+        pathname: `/eholdings/vendors/${vendor.id}/packages/${vendorPackage.id}/titles/${resource.titleId}`,
+        // our internal link component automatically sets the location state
+        state: { eholdings: true }
+      }, () => {
+        expect(ResourcePage.$root).to.exist;
+      });
+    });
+
+    it('should display the back button in UI', () => {
+      expect(ResourcePage.$backButton).to.exist;
     });
   });
 

--- a/tests/package-search-test.js
+++ b/tests/package-search-test.js
@@ -76,9 +76,9 @@ describeApplication('PackageSearch', () => {
           expect(PackageSearchPage.$root).to.not.exist;
         });
 
-        describe('and going back', () => {
-          beforeEach(function () {
-            return this.goBack(() => expect(PackageSearchPage.$root).to.exist);
+        describe('and clicking the back button', () => {
+          beforeEach(() => {
+            return PackageSearchPage.clickBackButton();
           });
 
           it('displays the original search', () => {

--- a/tests/package-show-test.js
+++ b/tests/package-show-test.js
@@ -65,6 +65,10 @@ describeApplication('PackageShow', () => {
       expect(PackageShowPage.titleList[0].isSelected).to.equal(customerResources[0].isSelected);
     });
 
+    it.still('should not display a back button', () => {
+      expect(PackageShowPage.$backButton).to.not.exist;
+    });
+
     describe('successfully selecting a package title to add to my holdings', () => {
       beforeEach(function () {
         /*
@@ -179,6 +183,23 @@ describeApplication('PackageShow', () => {
       });
     });
   });
+
+  describe('navigating to package show page', () => {
+    beforeEach(function () {
+      return this.visit({
+        pathname: `/eholdings/vendors/${vendor.id}/packages/${vendorPackage.id}`,
+        // our internal link component automatically sets the location state
+        state: { eholdings: true }
+      }, () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    it('should display the back button in UI', () => {
+      expect(PackageShowPage.$backButton).to.exist;
+    });
+  });
+
 
   describe('encountering a server error', () => {
     beforeEach(function () {

--- a/tests/pages/customer-resource-show.js
+++ b/tests/pages/customer-resource-show.js
@@ -92,4 +92,8 @@ export default {
   get contributorsList() {
     return $('[data-test-eholdings-contributors-list-item]').toArray().map(item => $(item).text());
   },
+
+  get $backButton() {
+    return $('[data-test-eholdings-customer-resource-show-back-button]');
+  }
 };

--- a/tests/pages/package-search.js
+++ b/tests/pages/package-search.js
@@ -81,5 +81,9 @@ export default {
       $title = $('[data-test-eholdings-title-list-item] a');
       expect($title.eq(index)).to.exist;
     }).then(() => $title.get(index).click());
+  },
+
+  clickBackButton() {
+    return $('[data-test-eholdings-customer-resource-show-back-button]').trigger('click');
   }
 };

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -83,5 +83,9 @@ export default {
 
   get customCoverage() {
     return $('[data-test-eholdings-package-details-custom-coverage]').text();
+  },
+
+  get $backButton() {
+    return $('[data-test-eholdings-package-details-back-button]');
   }
 };

--- a/tests/pages/title-search.js
+++ b/tests/pages/title-search.js
@@ -81,5 +81,9 @@ export default {
       $pkg = $('[data-test-eholdings-package-list-item] a');
       expect($pkg.eq(index)).to.exist;
     }).then(() => $pkg.get(index).click());
+  },
+
+  clickBackButton() {
+    return $('[data-test-eholdings-customer-resource-show-back-button]').trigger('click');
   }
 };

--- a/tests/pages/title-show.js
+++ b/tests/pages/title-show.js
@@ -49,5 +49,9 @@ export default {
 
   get packageList() {
     return $('[data-test-eholdings-title-show-package-list] li').toArray().map(createPackageObject);
+  },
+
+  get $backButton() {
+    return $('[data-test-eholdings-title-show-back-button]');
   }
 };

--- a/tests/pages/vendor-search.js
+++ b/tests/pages/vendor-search.js
@@ -81,5 +81,9 @@ export default {
       $pkg = $('[data-test-eholdings-package-list-item] a');
       expect($pkg.eq(index)).to.exist;
     }).then(() => $pkg.get(index).click());
+  },
+
+  clickBackButton() {
+    return $('[data-test-eholdings-package-details-back-button]').trigger('click');
   }
 };

--- a/tests/pages/vendor-show.js
+++ b/tests/pages/vendor-show.js
@@ -45,5 +45,9 @@ export default {
 
   get packageList() {
     return $('[data-test-eholdings-package-list-item]').toArray().map(createPackageObject);
+  },
+
+  get $backButton() {
+    return $('[data-test-eholdings-vendor-details-back-button]');
   }
 };

--- a/tests/title-search-test.js
+++ b/tests/title-search-test.js
@@ -78,9 +78,9 @@ describeApplication('TitleSearch', () => {
           expect(TitleSearchPage.$root).to.not.exist;
         });
 
-        describe('and going back', () => {
-          beforeEach(function () {
-            return this.goBack(() => expect(TitleSearchPage.$root).to.exist);
+        describe('and clicking the back button', () => {
+          beforeEach(() => {
+            return TitleSearchPage.clickBackButton();
           });
 
           it('displays the original search', () => {

--- a/tests/title-show-test.js
+++ b/tests/title-show-test.js
@@ -100,6 +100,26 @@ describeApplication('TitleShow', () => {
     it('displays whether the first customer resource is selected', () => {
       expect(TitleShowPage.packageList[0].isSelected).to.equal(customerResources[0].isSelected);
     });
+
+    it.still('should not display back button', () => {
+      expect(TitleShowPage.$backButton).to.not.exist;
+    });
+  });
+
+  describe('navigating to title page', () => {
+    beforeEach(function () {
+      return this.visit({
+        pathname: `/eholdings/titles/${title.id}`,
+        // our internal link component automatically sets the location state
+        state: { eholdings: true }
+      }, () => {
+        expect(TitleShowPage.$root).to.exist;
+      });
+    });
+
+    it('should display the back button in UI', () => {
+      expect(TitleShowPage.$backButton).to.exist;
+    });
   });
 
   describe('visiting the title page with some attributes undefined', () => {

--- a/tests/vendor-search-test.js
+++ b/tests/vendor-search-test.js
@@ -78,9 +78,9 @@ describeApplication('VendorSearch', () => {
           expect(VendorSearchPage.$root).to.not.exist;
         });
 
-        describe('and going back', () => {
-          beforeEach(function () {
-            return this.goBack(() => expect(VendorSearchPage.$root).to.exist);
+        describe('and clicking the back button', () => {
+          beforeEach(() => {
+            return VendorSearchPage.clickBackButton();
           });
 
           it('displays the original search', () => {

--- a/tests/vendor-show-test.js
+++ b/tests/vendor-show-test.js
@@ -52,7 +52,28 @@ describeApplication('VendorShow', () => {
     it('displays total number of titles for a package', () => {
       expect(VendorShowPage.packageList[0].numTitles).to.equal(packages[0].titleCount);
     });
+
+    it.still('should not display the back button', () => {
+      expect(VendorShowPage.$backButton).to.not.exist;
+    });
   });
+
+  describe('navigating to vendor details page', () => {
+    beforeEach(function () {
+      return this.visit({
+        pathname: `/eholdings/vendors/${vendor.id}`,
+        // our internal link component automatically sets the location state
+        state: { eholdings: true }
+      }, () => {
+        expect(VendorShowPage.$root).to.exist;
+      });
+    });
+
+    it('should display the back button in UI', () => {
+      expect(VendorShowPage.$backButton).to.exist;
+    });
+  });
+
 
   describe('encountering a server error', () => {
     beforeEach(function () {


### PR DESCRIPTION
## Purpose
Users need a way to step out / exit areas of the application and get back to another section as they navigate through the application. It is true that we have the back button in the web browser that will give user this functionality for free. However, as we have a response layout and user can be on varying devices the use of the native-button may not be a option. In addition having a back-button within the UI may feel more intuitive as Users are accustomed to clicking a `X` button to close things, `hamburger` icon to open hidden trays etc.

## Approach
Add a back button to:
* Package-details.
* Vendor-package-title aka customer-resource.
* Vendor-details.
* Title-details.

Create a `<Link />` Component that is used to track if a users location originated from within `eholdings`. That will allow us to render the back button if a User navigated from within `eholdings` but if they for example paste in the `url` to the browser the back-button will not be rendered as they did not originate from within `eholdings`.

## Screenshots

Back-button in action:
![2017-11-21 12 55 44](https://user-images.githubusercontent.com/1953098/33088738-7fcbbd8c-cebc-11e7-9600-ddc299f46c66.gif)


