### PR TITLE
Show Search Results Total

### DIFF
--- a/src/components/search-paneset/search-paneset.css
+++ b/src/components/search-paneset/search-paneset.css
@@ -20,6 +20,10 @@
   }
 }
 
+.search-heading {
+  text-align: center;
+}
+
 .scrollable-container {
   height: calc(100vh - 88px);
   overflow-y: scroll;

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -19,14 +19,19 @@ export default class SearchPaneset extends React.Component {
     resultsType: PropTypes.string,
     resultsView: PropTypes.node,
     detailsView: PropTypes.node,
+    totalResults: PropTypes.number,
     location: PropTypes.object
-  }
+  };
+
+  static defaultProps = {
+    totalResults: 0
+  };
 
   static contextTypes = {
     router: PropTypes.shape({
       history: PropTypes.object
     })
-  }
+  };
 
   state = {
     hideFilters: this.props.hideFilters
@@ -55,7 +60,13 @@ export default class SearchPaneset extends React.Component {
 
   render() {
     let { hideFilters } = this.state;
-    let { searchForm, resultsType, resultsView, detailsView } = this.props;
+    let {
+      searchForm,
+      resultsType,
+      resultsView,
+      detailsView,
+      totalResults
+    } = this.props;
 
     // only hide filters if there are results and always hide filters when a detail view is visible
     hideFilters = (hideFilters && !!resultsView) || !!detailsView;
@@ -83,7 +94,14 @@ export default class SearchPaneset extends React.Component {
         {!!resultsView && (
           <ResultsPane>
             <PaneHeader
-              paneTitle={capitalize(resultsType)}
+              paneTitle={(
+                <div className={styles['search-heading']}>
+                  <strong>{capitalize(resultsType)}</strong>
+                  <div data-test-eholdings-total-search-results>
+                    <em>{totalResults} search results</em>
+                  </div>
+                </div>
+              )}
               firstMenu={(
                 <PaneMenu><button onClick={this.toggleFilters} className={styles['results-pane-search-toggle']}>&larr; Search</button></PaneMenu>
               )}

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -188,7 +188,7 @@ class SearchRoute extends Component {
 
     if (searchType) {
       let hideDetails = /^\/eholdings\/?$/.test(location.pathname);
-      let { params } = results.request;
+      let { params, meta } = results.request;
 
       return (
         <div data-test-eholdings>
@@ -198,6 +198,7 @@ class SearchRoute extends Component {
             resultsType={searchType}
             resultsView={this.renderResults()}
             detailsView={!hideDetails && children}
+            totalResults={meta.totalResults}
             searchForm={(
               <SearchForm
                 searchType={searchType}

--- a/tests/package-search-test.js
+++ b/tests/package-search-test.js
@@ -45,6 +45,10 @@ describeApplication('PackageSearch', () => {
       expect(PackageSearchPage.packageList[0].vendorName).to.equal(pkgs[0].vendor.name);
     });
 
+    it('displays the total number of search results', () => {
+      expect(PackageSearchPage.totalResults).to.equal('3 search results');
+    });
+
     describe('clicking a search results list item', () => {
       beforeEach(() => {
         return convergeOn(() => {

--- a/tests/pages/package-search.js
+++ b/tests/pages/package-search.js
@@ -38,6 +38,10 @@ export default {
     return $('[data-test-package-search-results-list] li a');
   },
 
+  get totalResults() {
+    return $('[data-test-eholdings-total-search-results]').text();
+  },
+
   get hasErrors() {
     return $('[data-test-package-search-error-message]').length > 0;
   },

--- a/tests/pages/title-search.js
+++ b/tests/pages/title-search.js
@@ -38,6 +38,10 @@ export default {
     return $('[data-test-title-search-results-list] li a');
   },
 
+  get totalResults() {
+    return $('[data-test-eholdings-total-search-results]').text();
+  },
+
   get hasErrors() {
     return $('[data-test-title-search-error-message]').length > 0;
   },

--- a/tests/pages/vendor-search.js
+++ b/tests/pages/vendor-search.js
@@ -34,6 +34,10 @@ export default {
     return $('[data-test-vendor-search-results-list] li a');
   },
 
+  get totalResults() {
+    return $('[data-test-eholdings-total-search-results]').text();
+  },
+
   get hasErrors() {
     return $('[data-test-vendor-search-error-message]').length > 0;
   },

--- a/tests/title-search-test.js
+++ b/tests/title-search-test.js
@@ -47,6 +47,10 @@ describeApplication('TitleSearch', () => {
       expect(TitleSearchPage.titleList[0].publicationType).to.equal(titles[0].publicationType);
     });
 
+    it('displays the total number of search results', () => {
+      expect(TitleSearchPage.totalResults).to.equal('3 search results');
+    });
+
     describe('clicking a search results list item', () => {
       beforeEach(() => {
         return convergeOn(() => {

--- a/tests/vendor-search-test.js
+++ b/tests/vendor-search-test.js
@@ -47,6 +47,10 @@ describeApplication('VendorSearch', () => {
       expect(VendorSearchPage.vendorList[0].numPackages).to.equal(3);
     });
 
+    it('displays the total number of search results', () => {
+      expect(VendorSearchPage.totalResults).to.equal('3 search results');
+    });
+
     describe('clicking a search results list item', () => {
       beforeEach(() => {
         return convergeOn(() => {


### PR DESCRIPTION
## Purpose
Show the search results total for vendors, packages, and titles

## Approach
Copies how the total number is displayed for ui-users (under the results pane header).

## Screenshots
![image](https://user-images.githubusercontent.com/5005153/33098369-cc228bdc-ced2-11e7-9794-9f4c0cfab5cc.png)

