### PR TITLE
Show back button only if there is no query string

### DIFF
--- a/src/components/package-show/package-show.js
+++ b/src/components/package-show/package-show.js
@@ -17,11 +17,11 @@ export default function PackageShow({
   vendorPackage,
   packageTitles,
   toggleRequest,
-  toggleSelected,
-  queryString
+  toggleSelected
 }, { intl, router }) {
   let packageRecord = vendorPackage.content;
-  let historyState = router.history.location.state;
+  const historyState = router.history.location.state;
+  const queryString = router.history.location.search;
 
   return (
     <div>
@@ -142,7 +142,6 @@ PackageShow.propTypes = {
   packageTitles: PropTypes.object.isRequired,
   toggleRequest: PropTypes.object.isRequired,
   toggleSelected: PropTypes.func.isRequired,
-  queryString: PropTypes.string
 };
 
 PackageShow.contextTypes = {

--- a/src/components/package-show/package-show.js
+++ b/src/components/package-show/package-show.js
@@ -21,7 +21,7 @@ export default function PackageShow({
 }, { intl, router }) {
   let packageRecord = vendorPackage.content;
   const historyState = router.history.location.state;
-  const queryString = router.history.location.search;
+  const queryString = router.route.location.search;
 
   return (
     <div>

--- a/src/components/title-show/title-show.js
+++ b/src/components/title-show/title-show.js
@@ -14,11 +14,11 @@ import { formatPublicationType } from '../utilities';
 import styles from './title-show.css';
 
 export default function TitleShow({
-  title,
-  queryString
+  title
 }, { router }) {
   let record = title.content;
-  let historyState = router.history.location.state;
+  const historyState = router.history.location.state;
+  const queryString = router.history.location.search;
 
   return (
     <div>
@@ -91,8 +91,7 @@ export default function TitleShow({
 }
 
 TitleShow.propTypes = {
-  title: PropTypes.object.isRequired,
-  queryString: PropTypes.string
+  title: PropTypes.object.isRequired
 };
 
 TitleShow.contextTypes = {

--- a/src/components/title-show/title-show.js
+++ b/src/components/title-show/title-show.js
@@ -18,7 +18,7 @@ export default function TitleShow({
 }, { router }) {
   let record = title.content;
   const historyState = router.history.location.state;
-  const queryString = router.history.location.search;
+  const queryString = router.route.location.search;
 
   return (
     <div>

--- a/src/components/vendor-show/vendor-show.js
+++ b/src/components/vendor-show/vendor-show.js
@@ -12,11 +12,11 @@ import styles from './vendor-show.css';
 
 export default function VendorShow({
   vendor,
-  vendorPackages,
-  queryString
+  vendorPackages
 }, { router }) {
   const record = vendor.content;
-  let historyState = router.history.location.state;
+  const historyState = router.history.location.state;
+  const queryString = router.history.location.search;
 
   return (
     <div>
@@ -87,8 +87,7 @@ export default function VendorShow({
 
 VendorShow.propTypes = {
   vendor: PropTypes.object.isRequired,
-  vendorPackages: PropTypes.object.isRequired,
-  queryString: PropTypes.string
+  vendorPackages: PropTypes.object.isRequired
 };
 
 VendorShow.contextTypes = {

--- a/src/components/vendor-show/vendor-show.js
+++ b/src/components/vendor-show/vendor-show.js
@@ -16,7 +16,7 @@ export default function VendorShow({
 }, { router }) {
   const record = vendor.content;
   const historyState = router.history.location.state;
-  const queryString = router.history.location.search;
+  const queryString = router.route.location.search;
 
   return (
     <div>

--- a/tests/package-search-test.js
+++ b/tests/package-search-test.js
@@ -57,6 +57,10 @@ describeApplication('PackageSearch', () => {
         expect(PackageSearchPage.previewPaneIsVisible).to.be.true;
       });
 
+      it('should not display button in UI', () => {
+        expect(PackageSearchPage.$backButton).to.not.exist;
+      });
+
       describe('clicking the vignette behind the preview pane', () => {
         beforeEach(() => {
           PackageSearchPage.clickSearchVignette();

--- a/tests/pages/package-search.js
+++ b/tests/pages/package-search.js
@@ -54,6 +54,10 @@ export default {
     return $('[data-test-package-search-results-list] li').toArray().map(createPackageObject);
   },
 
+  get $backButton() {
+    return $('[data-test-eholdings-package-details-back-button');
+  },
+
   clickSearchVignette() {
     return $('[data-test-search-vignette]').trigger('click');
   },

--- a/tests/pages/title-search.js
+++ b/tests/pages/title-search.js
@@ -54,6 +54,10 @@ export default {
     return $('[data-test-title-search-results-list] li').toArray().map(createTitleObject);
   },
 
+  get $backButton() {
+    return $('[data-test-eholdings-title-show-back-button]');
+  },
+
   clickSearchVignette() {
     return $('[data-test-search-vignette]').trigger('click');
   },

--- a/tests/pages/vendor-search.js
+++ b/tests/pages/vendor-search.js
@@ -54,6 +54,10 @@ export default {
     return $('[data-test-vendor-search-results-list] li').toArray().map(createVendorObject);
   },
 
+  get $backButton() {
+    return $('[data-test-eholdings-vendor-details-back-button');
+  },
+
   clickSearchVignette() {
     return $('[data-test-search-vignette]').trigger('click');
   },

--- a/tests/title-search-test.js
+++ b/tests/title-search-test.js
@@ -59,6 +59,10 @@ describeApplication('TitleSearch', () => {
         expect(TitleSearchPage.previewPaneIsVisible).to.be.true;
       });
 
+      it('should not display back button in UI', () => {
+        expect(TitleSearchPage.$backButton).to.not.exist;
+      });
+
       describe('clicking the vignette behind the preview pane', () => {
         beforeEach(() => {
           TitleSearchPage.clickSearchVignette();

--- a/tests/vendor-search-test.js
+++ b/tests/vendor-search-test.js
@@ -59,6 +59,10 @@ describeApplication('VendorSearch', () => {
         expect(VendorSearchPage.previewPaneIsVisible).to.be.true;
       });
 
+      it('should not display button in UI', () => {
+        expect(VendorSearchPage.$backButton).to.not.exist;
+      });
+
       describe('clicking the vignette behind the preview pane', () => {
         beforeEach(() => {
           VendorSearchPage.clickSearchVignette();


### PR DESCRIPTION
## Purpose
Back button should not show if there is a queryString meaning that there was a search performed. There is already an exit button. The back-button is redundant and not useful in this context. A User in this context would just want to "close" this search detail pane completely and not step back.

## Problem
Prior we were using a queryString value that seemed to be only passed in through props on a Vendor and not Package or Title. So on a Package or Title search detail pane there would be a "X" and "<-" rendered in the UI.

## Approach
- Check the router to see if a search property exist.

## Screenshots
### Before:

<img width="1406" alt="screen shot 2017-11-22 at 5 59 40 pm" src="https://user-images.githubusercontent.com/1953098/33154661-e63d375c-cfb7-11e7-989a-43045571748b.png">

### After:
<img width="1693" alt="screen shot 2017-11-22 at 7 05 38 pm" src="https://user-images.githubusercontent.com/1953098/33154689-2f875e74-cfb8-11e7-9128-ed590879bd27.png">


