### PR TITLE
Update to stripes-connect release

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@folio/stripes-components": "thefrontside/stripes-components#master",
+    "@folio/stripes-connect": "^3.0.0",
     "@folio/stripes-core": "thefrontside/stripes-core#master",
     "babel-core": "^6.25.0",
     "babel-eslint": "^8.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,9 +29,9 @@
     redux-form "^7.0.3"
     typeface-source-sans-pro "^0.0.44"
 
-"@folio/stripes-connect@^3.0.0-pre.1":
+"@folio/stripes-connect@^3.0.0", "@folio/stripes-connect@^3.0.0-pre.1":
   version "3.0.0"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-connect/-/stripes-connect-3.0.0.tgz#87634148bc68c2eed2acfc784474382f00cafaa6"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-connect/-/stripes-connect-3.0.0.tgz#d3a3b05f8cd786c4bd848bf6a870b51b95173859"
   dependencies:
     isomorphic-fetch "^2.2.1"
     lodash "^4.17.2"


### PR DESCRIPTION
## Purpose
Something wonky happened with today's `stripes-connect` release where previous commit hashes disappeared.

When running `yarn`:
<img width="583" alt="screen shot 2017-12-05 at 3 53 44 pm" src="https://user-images.githubusercontent.com/230597/33637349-569d212a-d9d5-11e7-8c27-c0beb736ebed.png">

## Approach
It's been fixed in `stripes-core`, but upgrading to the latest there caused some test failures that need more investigation. Instead we can just request the explicit release version in `ui-eholdings`.
