### PR TITLE
Adjust some CSS post-reset

### DIFF
--- a/src/components/customer-resource-show/customer-resource-show.css
+++ b/src/components/customer-resource-show/customer-resource-show.css
@@ -1,5 +1,19 @@
 .detail-container {
   padding: 0 1rem;
+
+  & h1 {
+    font-size: 2.5em;
+    font-weight: 700;
+    margin-top: 0.125em;
+  }
+
+  & h3 {
+    margin: 1em 0 0.5em;
+  }
+
+  & h4 {
+    margin: 0.5em 0;
+  }
 }
 
 .detail-container-header {

--- a/src/components/list/list.css
+++ b/src/components/list/list.css
@@ -15,13 +15,16 @@
       text-decoration: none;
       display: block;
       padding: 1em;
+      color: #888;
 
       &:hover {
         background-color: #eee;
       }
 
       & h5 {
-        margin: 0;
+        color: #555;
+        font-weight: 600;
+        margin-bottom: 0.5em;
       }
     }
   }

--- a/src/components/package-show/package-show.css
+++ b/src/components/package-show/package-show.css
@@ -1,5 +1,19 @@
 .detail-container {
   padding: 0 1rem;
+
+  & h1 {
+    font-size: 2.5em;
+    font-weight: 700;
+    margin-top: 0.125em;
+  }
+
+  & h3 {
+    margin: 1em 0 0.5em;
+  }
+
+  & h4 {
+    margin: 0.5em 0;
+  }
 }
 
 .detail-container-header {

--- a/src/components/search-form/search-form.css
+++ b/src/components/search-form/search-form.css
@@ -39,6 +39,10 @@
       border-bottom-left-radius: 0;
     }
 
+    &:visited {
+      color: var(--primary);
+    }
+
     &.is-active {
       background-color: var(--primary);
       color: #fff;

--- a/src/components/title-show/title-show.css
+++ b/src/components/title-show/title-show.css
@@ -1,5 +1,15 @@
 .detail-container {
   padding: 0 1rem;
+
+  & h1 {
+    font-size: 2.5em;
+    font-weight: 700;
+    margin-top: 0.125em;
+  }
+
+  & h3 {
+    margin: 1em 0 0.5em;
+  }
 }
 
 .detail-container-header {

--- a/src/components/vendor-show/vendor-show.css
+++ b/src/components/vendor-show/vendor-show.css
@@ -1,5 +1,15 @@
 .detail-container {
   padding: 0 1rem;
+
+  & h1 {
+    font-size: 2.5em;
+    font-weight: 700;
+    margin-top: 0.125em;
+  }
+
+  & h3 {
+    margin: 1em 0 0.5em;
+  }
 }
 
 .detail-container-header {


### PR DESCRIPTION
## Purpose
`stripes-components` now has a reset stylesheet. The biggest side effect was that we lost a lot of spacing.

## Approach
I also bumped up some headline sizes/weights and tweaked the style of the search form's segmented control.

## Screenshots
![localhost_3000_eholdings_vendors_1_packages_1_titles_1 iphone 5](https://user-images.githubusercontent.com/230597/33862138-3aa9c4c6-de96-11e7-94d8-85e199e25a5c.png)

![localhost_3000_ iphone 5](https://user-images.githubusercontent.com/230597/33862139-3ac6b3ec-de96-11e7-8d15-096e2eabcf00.png)

