### PR TITLE
Add permissionSets to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,13 @@
     "hasSettings": true,
     "okapiInterfaces": {
       "kb-ebsco": "0.1.0"
-    }
+    },
+    "permissionSets": [
+        {
+        "permissionName": "module.eholdings.enabled",
+        "displayName": "UI: eHoldings module is enabled",
+        "visible": true
+      }
+    ]
   }
 }


### PR DESCRIPTION
From @MikeTaylor:
This is necessary for Stripes to display the icon of the eholdings application in its top bar and to enable the route `eholdings`.