### PR TITLE
Explicitly declare model types

### DIFF
--- a/src/redux/application.js
+++ b/src/redux/application.js
@@ -1,6 +1,7 @@
 import model from './model';
 
 export const Status = model({
+  type: 'statuses',
   // id is 'status' so it will be appended to this when retrieving
   // the status
   path: '/eholdings'

--- a/src/redux/package.js
+++ b/src/redux/package.js
@@ -14,5 +14,6 @@ class Package {
 }
 
 export default model({
+  type: 'packages',
   path: '/eholdings/jsonapi/packages'
 })(Package);

--- a/src/redux/title.js
+++ b/src/redux/title.js
@@ -11,5 +11,6 @@ class Title {
 }
 
 export default model({
+  type: 'titles',
   path: '/eholdings/jsonapi/titles'
 })(Title);

--- a/src/redux/vendor.js
+++ b/src/redux/vendor.js
@@ -8,5 +8,6 @@ class Vendor {
 }
 
 export default model({
+  type: 'vendors',
   path: '/eholdings/jsonapi/vendors'
 })(Vendor);


### PR DESCRIPTION
## Purpose
When uglified, the production build does not include class names for these models. So when the model helper tries to infer a model type from the class name, they all become "es".

## Approach
Explicitly set a type for each model so that the class name does not matter

#### Open Questions
- Should the production build be losing class names? Is this a setting we have control over in stripes?

## Screenshots
**Production Model Names**

![image](https://user-images.githubusercontent.com/5005153/34217894-565b478e-e572-11e7-9937-afe09da9e54f.png)

**Development Model Names**

![image](https://user-images.githubusercontent.com/5005153/34217902-5a54f3da-e572-11e7-9a76-e9ba63387b3d.png)

