### PR TITLE
Remove /jsonapi namespace

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -104,7 +104,7 @@ export default function configure() {
   });
 
   // Vendor resources
-  this.get('/jsonapi/vendors', function ({ vendors }, request) { // eslint-disable-line func-names
+  this.get('/vendors', function ({ vendors }, request) { // eslint-disable-line func-names
     let json = this.serialize(vendors.all().filter((vendorModel) => {
       let query = request.queryParams.q.toLowerCase();
       return vendorModel.name.toLowerCase().includes(query);
@@ -114,12 +114,12 @@ export default function configure() {
     return json;
   });
 
-  this.get('/jsonapi/vendors/:id', ({ vendors }, request) => {
+  this.get('/vendors/:id', ({ vendors }, request) => {
     return vendors.find(request.params.id);
   });
 
   // Package resources
-  this.get('/jsonapi/packages', function ({ packages }, request) { // eslint-disable-line func-names
+  this.get('/packages', function ({ packages }, request) { // eslint-disable-line func-names
     let json = this.serialize(packages.all().filter((packageModel) => {
       const query = request.queryParams.q.toLowerCase();
       return packageModel.name.toLowerCase().includes(query);
@@ -129,13 +129,13 @@ export default function configure() {
     return json;
   });
 
-  this.get('/jsonapi/packages/:id', ({ packages }, request) => {
+  this.get('/packages/:id', ({ packages }, request) => {
     return packages.findBy({
       id: request.params.id
     });
   });
 
-  this.put('/jsonapi/packages/:id', ({ packages, customerResources }, request) => {
+  this.put('/packages/:id', ({ packages, customerResources }, request) => {
     let matchingPackage = packages.findBy({
       id: request.params.id
     });
@@ -156,12 +156,12 @@ export default function configure() {
     return matchingPackage;
   });
 
-  this.get('/jsonapi/packages/:packageId/customer-resources', ({ customerResources }, request) => {
+  this.get('/packages/:packageId/customer-resources', ({ customerResources }, request) => {
     return customerResources.where({ packageId: request.params.packageId });
   });
 
   // Title resources
-  this.get('/jsonapi/titles', function ({ titles }, request) { // eslint-disable-line func-names
+  this.get('/titles', function ({ titles }, request) { // eslint-disable-line func-names
     let json = this.serialize(titles.all().filter((titleModel) => {
       const query = request.queryParams.q.toLowerCase();
       return titleModel.name.toLowerCase().includes(query);
@@ -171,20 +171,20 @@ export default function configure() {
     return json;
   });
 
-  this.get('/jsonapi/titles/:id', ({ titles }, request) => {
+  this.get('/titles/:id', ({ titles }, request) => {
     return titles.find(request.params.id);
   });
 
   // Customer Resource resources
-  this.get('/jsonapi/customer-resources', ({ customerResources }, request) => {
+  this.get('/customer-resources', ({ customerResources }, request) => {
     return customerResources.where({ packageId: request.params.packageId });
   });
 
-  this.get('/jsonapi/customer-resources/:id', ({ customerResources }, request) => {
+  this.get('/customer-resources/:id', ({ customerResources }, request) => {
     return customerResources.findBy({ id: request.params.id });
   });
 
-  this.put('/jsonapi/customer-resources/:id', ({ customerResources }, request) => {
+  this.put('/customer-resources/:id', ({ customerResources }, request) => {
     let matchingCustomerResource = customerResources.findBy({
       id: request.params.id
     });

--- a/src/redux/customer-resource.js
+++ b/src/redux/customer-resource.js
@@ -23,5 +23,5 @@ class CustomerResource {
 
 export default model({
   type: 'customerResources',
-  path: '/eholdings/jsonapi/customer-resources'
+  path: '/eholdings/customer-resources'
 })(CustomerResource);

--- a/src/redux/package.js
+++ b/src/redux/package.js
@@ -15,5 +15,5 @@ class Package {
 
 export default model({
   type: 'packages',
-  path: '/eholdings/jsonapi/packages'
+  path: '/eholdings/packages'
 })(Package);

--- a/src/redux/title.js
+++ b/src/redux/title.js
@@ -12,5 +12,5 @@ class Title {
 
 export default model({
   type: 'titles',
-  path: '/eholdings/jsonapi/titles'
+  path: '/eholdings/titles'
 })(Title);

--- a/src/redux/vendor.js
+++ b/src/redux/vendor.js
@@ -9,5 +9,5 @@ class Vendor {
 
 export default model({
   type: 'vendors',
-  path: '/eholdings/jsonapi/vendors'
+  path: '/eholdings/vendors'
 })(Vendor);

--- a/tests/customer-resource-show-test.js
+++ b/tests/customer-resource-show-test.js
@@ -163,7 +163,7 @@ describeApplication('CustomerResourceShow', () => {
 
     describe('unsuccessfully selecting a package title to add to my holdings', () => {
       beforeEach(function () {
-        this.server.put('/jsonapi/customer-resources/:id', {
+        this.server.put('/customer-resources/:id', {
           errors: [{
             title: 'There was an error'
           }]
@@ -297,7 +297,7 @@ describeApplication('CustomerResourceShow', () => {
 
   describe('encountering a server error', () => {
     beforeEach(function () {
-      this.server.get('/jsonapi/customer-resources/:id', {
+      this.server.get('/customer-resources/:id', {
         errors: [{
           title: 'There was an error'
         }]

--- a/tests/package-search-test.js
+++ b/tests/package-search-test.js
@@ -154,7 +154,7 @@ describeApplication('PackageSearch', () => {
 
   describe('encountering a server error', () => {
     beforeEach(function () {
-      this.server.get('/jsonapi/packages', {
+      this.server.get('/packages', {
         errors: [{
           title: 'There was an error'
         }]

--- a/tests/package-show-test.js
+++ b/tests/package-show-test.js
@@ -142,7 +142,7 @@ describeApplication('PackageShow', () => {
 
     describe('unsuccessfully selecting a package title to add to my holdings', () => {
       beforeEach(function () {
-        this.server.put('/jsonapi/packages/:packageId', {
+        this.server.put('/packages/:packageId', {
           errors: [{
             title: 'There was an error'
           }]
@@ -203,7 +203,7 @@ describeApplication('PackageShow', () => {
 
   describe('encountering a server error', () => {
     beforeEach(function () {
-      this.server.get('/jsonapi/packages/:packageId', {
+      this.server.get('/packages/:packageId', {
         errors: [{
           title: 'There was an error'
         }]

--- a/tests/title-search-test.js
+++ b/tests/title-search-test.js
@@ -156,7 +156,7 @@ describeApplication('TitleSearch', () => {
 
   describe('encountering a server error', () => {
     beforeEach(function () {
-      this.server.get('/jsonapi/titles', {
+      this.server.get('/titles', {
         errors: [{
           title: 'There was an error'
         }]

--- a/tests/vendor-search-test.js
+++ b/tests/vendor-search-test.js
@@ -161,7 +161,7 @@ describeApplication('VendorSearch', () => {
 
   describe('encountering a server error', () => {
     beforeEach(function () {
-      this.server.get('/jsonapi/vendors', {
+      this.server.get('/vendors', {
         errors: [{
           title: 'There was an error'
         }]

--- a/tests/vendor-show-test.js
+++ b/tests/vendor-show-test.js
@@ -77,7 +77,7 @@ describeApplication('VendorShow', () => {
 
   describe('encountering a server error', () => {
     beforeEach(function () {
-      this.server.get('/jsonapi/vendors/:id', {
+      this.server.get('/vendors/:id', {
         errors: [{
           title: 'There was an error'
         }]


### PR DESCRIPTION
Now that we're exclusively using the new `mod-kb-ebsco` JSON API endpoints, we no longer need them sandboxed under `/jsonapi/`.