### PR TITLE
Format results number with intl-friendly separators

### DIFF
--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -28,6 +28,7 @@ export default class SearchPaneset extends React.Component {
   };
 
   static contextTypes = {
+    intl: PropTypes.object,
     router: PropTypes.shape({
       history: PropTypes.object
     })
@@ -67,6 +68,7 @@ export default class SearchPaneset extends React.Component {
       detailsView,
       totalResults
     } = this.props;
+    let { intl } = this.context;
 
     // only hide filters if there are results and always hide filters when a detail view is visible
     hideFilters = (hideFilters && !!resultsView) || !!detailsView;
@@ -98,7 +100,7 @@ export default class SearchPaneset extends React.Component {
                 <div className={styles['search-heading']}>
                   <strong>{capitalize(resultsType)}</strong>
                   <div data-test-eholdings-total-search-results>
-                    <em>{totalResults} search results</em>
+                    <em>{intl.formatNumber(totalResults)} search results</em>
                   </div>
                 </div>
               )}


### PR DESCRIPTION
FOLIO apps should internationalize numbers. In my locale, a comma gets added as a thousands separator:

![localhost_3000_eholdings__searchtype titles q th iphone 7](https://user-images.githubusercontent.com/230597/34228344-311fa402-e585-11e7-94fc-27216d54cb59.png)
