### PR TITLE
Pluralize configuration type

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -91,7 +91,7 @@ export default function configure() {
   this.get('/configuration', {
     data: {
       id: 'configuration',
-      type: 'configuration',
+      type: 'configurations',
       attributes: {
         customerId: 'some-valid-customer-id',
         apiKey: 'some-valid-api-key'

--- a/mirage/scenarios/unconfigured-backend.js
+++ b/mirage/scenarios/unconfigured-backend.js
@@ -12,7 +12,7 @@ export default function unconfiguredBackendScenario(server) {
   server.get('/configuration', {
     data: {
       id: 'configuration',
-      type: 'configuration',
+      type: 'configurations',
       attributes: {
         customerId: '',
         apiKey: ''

--- a/src/redux/application.js
+++ b/src/redux/application.js
@@ -12,7 +12,7 @@ export const Status = model({
 );
 
 export const Configuration = model({
-  type: 'configuration',
+  type: 'configurations',
   // id is 'configuration' so it will be appended to this path when
   // retrieving the configuration
   path: '/eholdings'

--- a/src/routes/settings.js
+++ b/src/routes/settings.js
@@ -49,7 +49,7 @@ class SettingsRoute extends Component {
 
 export default connect(
   ({ eholdings: { data } }) => ({
-    config: createResolver(data).find('configuration', 'configuration')
+    config: createResolver(data).find('configurations', 'configuration')
   }), {
     getBackendConfig: () => Configuration.find('configuration'),
     updateBackendConfig: model => Configuration.save(model)


### PR DESCRIPTION
## Purpose
eHoldings settings is broken.

## Approach
The `configurations` endpoint needs type `configurations` and id `configuration`. It's currently returning type `configuration` and id `rmapi`.

